### PR TITLE
chore(backend-spring): phase 1 cross-cutting foundation

### DIFF
--- a/backend-spring/build.gradle.kts
+++ b/backend-spring/build.gradle.kts
@@ -18,15 +18,24 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.testcontainers:testcontainers-bom:1.21.1")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    runtimeOnly("org.postgresql:postgresql")
 
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testImplementation("org.springframework.boot:spring-boot-starter-validation-test")
-    // Testcontainers (junit-jupiter + postgresql, via the Testcontainers BOM) is added
-    // in Phase 1 (#76) when DB integration lands — Boot 4.0's BOM doesn't manage its version.
+    testImplementation("org.springframework.boot:spring-boot-resttestclient")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:postgresql")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/backend-spring/settings.gradle.kts
+++ b/backend-spring/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "backend"
+rootProject.name = "backend-spring"

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/HomestayBackendApplication.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/HomestayBackendApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class HomestayBackendApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(HomestayBackendApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(HomestayBackendApplication.class, args);
+    }
 }

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/config/GlobalExceptionHandler.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/config/GlobalExceptionHandler.java
@@ -1,0 +1,57 @@
+package vn.edu.hcmus.homestay.config;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import vn.edu.hcmus.homestay.support.ApiResponse;
+import vn.edu.hcmus.homestay.support.ApiResponseBuilder;
+import vn.edu.hcmus.homestay.support.AppException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(AppException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAppException(AppException ex) {
+        return ResponseEntity.status(ex.getStatusCode())
+                .body(ApiResponseBuilder.error(ex.getCode(), ex.getMessage(), ex.getDetails()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException ex) {
+        List<Object> details =
+                ex.getBindingResult().getFieldErrors().stream()
+                        .map(fe -> (Object) (fe.getField() + ": " + fe.getDefaultMessage()))
+                        .toList();
+        return ResponseEntity.badRequest()
+                .body(ApiResponseBuilder.error("VALIDATION_ERROR", "Validation failed", details));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<Void>> handlePayloadTooLarge(MaxUploadSizeExceededException ex) {
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+                .body(ApiResponseBuilder.error(
+                        "PAYLOAD_TOO_LARGE", "Request body is too large. Current limit is 25MB."));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoHandler(NoHandlerFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponseBuilder.error("NOT_FOUND", "Route not found"));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneric(Exception ex) {
+        log.error("Unhandled exception", ex);
+        return ResponseEntity.internalServerError()
+                .body(ApiResponseBuilder.error("INTERNAL_SERVER_ERROR", "Internal Server Error"));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/config/JpaConfig.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/config/JpaConfig.java
@@ -1,0 +1,8 @@
+package vn.edu.hcmus.homestay.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/config/WebConfig.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/config/WebConfig.java
@@ -1,0 +1,43 @@
+package vn.edu.hcmus.homestay.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*");
+    }
+
+    @Bean
+    public OncePerRequestFilter securityHeadersFilter() {
+        return new OncePerRequestFilter() {
+            @Override
+            protected void doFilterInternal(
+                    HttpServletRequest request,
+                    HttpServletResponse response,
+                    FilterChain chain)
+                    throws ServletException, IOException {
+                response.setHeader("X-Content-Type-Options", "nosniff");
+                response.setHeader("X-Frame-Options", "SAMEORIGIN");
+                response.setHeader("X-DNS-Prefetch-Control", "off");
+                response.setHeader(
+                        "Strict-Transport-Security", "max-age=15552000; includeSubDomains");
+                chain.doFilter(request, response);
+            }
+        };
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/ApiResponse.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/ApiResponse.java
@@ -1,0 +1,44 @@
+package vn.edu.hcmus.homestay.support;
+
+import java.util.List;
+
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final T data;
+    private final String message;
+    private final ErrorBody error;
+
+    private ApiResponse(boolean success, T data, String message, ErrorBody error) {
+        this.success = success;
+        this.data = data;
+        this.message = message;
+        this.error = error;
+    }
+
+    static <T> ApiResponse<T> ok(T data, String message) {
+        return new ApiResponse<>(true, data, message, null);
+    }
+
+    static ApiResponse<Void> fail(String code, String message, List<Object> details) {
+        return new ApiResponse<>(false, null, null, new ErrorBody(code, message, details));
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public ErrorBody getError() {
+        return error;
+    }
+
+    public record ErrorBody(String code, String message, List<Object> details) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/ApiResponseBuilder.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/ApiResponseBuilder.java
@@ -1,0 +1,24 @@
+package vn.edu.hcmus.homestay.support;
+
+import java.util.List;
+
+public final class ApiResponseBuilder {
+
+    private ApiResponseBuilder() {}
+
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.ok(data, null);
+    }
+
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return ApiResponse.ok(data, message);
+    }
+
+    public static ApiResponse<Void> error(String code, String message) {
+        return ApiResponse.fail(code, message, null);
+    }
+
+    public static ApiResponse<Void> error(String code, String message, List<Object> details) {
+        return ApiResponse.fail(code, message, details);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/AppException.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/AppException.java
@@ -1,0 +1,36 @@
+package vn.edu.hcmus.homestay.support;
+
+import java.util.List;
+
+public class AppException extends RuntimeException {
+
+    private final int statusCode;
+    private final String code;
+    private final List<Object> details;
+
+    public AppException(int statusCode, String code, String message) {
+        super(message);
+        this.statusCode = statusCode;
+        this.code = code;
+        this.details = null;
+    }
+
+    public AppException(int statusCode, String code, String message, List<Object> details) {
+        super(message);
+        this.statusCode = statusCode;
+        this.code = code;
+        this.details = details;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public List<Object> getDetails() {
+        return details;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/BaseEntity.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/BaseEntity.java
@@ -1,0 +1,42 @@
+package vn.edu.hcmus.homestay.support;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/ConflictException.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/ConflictException.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.support;
+
+public class ConflictException extends AppException {
+
+    public ConflictException(String message) {
+        super(409, "CONFLICT", message);
+    }
+
+    public ConflictException() {
+        super(409, "CONFLICT", "Conflict");
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/ForbiddenException.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/ForbiddenException.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.support;
+
+public class ForbiddenException extends AppException {
+
+    public ForbiddenException(String message) {
+        super(403, "FORBIDDEN", message);
+    }
+
+    public ForbiddenException() {
+        super(403, "FORBIDDEN", "Forbidden");
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/NotFoundException.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/NotFoundException.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.support;
+
+public class NotFoundException extends AppException {
+
+    public NotFoundException(String message) {
+        super(404, "NOT_FOUND", message);
+    }
+
+    public NotFoundException() {
+        super(404, "NOT_FOUND", "Not found");
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/PaginatedResponse.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/PaginatedResponse.java
@@ -1,0 +1,29 @@
+package vn.edu.hcmus.homestay.support;
+
+import java.util.List;
+
+public class PaginatedResponse<T> {
+
+    private final boolean success = true;
+    private final List<T> data;
+    private final Pagination pagination;
+
+    public PaginatedResponse(List<T> data, Pagination pagination) {
+        this.data = data;
+        this.pagination = pagination;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public List<T> getData() {
+        return data;
+    }
+
+    public Pagination getPagination() {
+        return pagination;
+    }
+
+    public record Pagination(int page, int limit, long total, int pages) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/UnauthorizedException.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/UnauthorizedException.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.support;
+
+public class UnauthorizedException extends AppException {
+
+    public UnauthorizedException(String message) {
+        super(401, "UNAUTHORIZED", message);
+    }
+
+    public UnauthorizedException() {
+        super(401, "UNAUTHORIZED", "Unauthorized");
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/ValidationException.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/support/ValidationException.java
@@ -1,0 +1,14 @@
+package vn.edu.hcmus.homestay.support;
+
+import java.util.List;
+
+public class ValidationException extends AppException {
+
+    public ValidationException(String message) {
+        super(400, "VALIDATION_ERROR", message);
+    }
+
+    public ValidationException(String message, List<Object> details) {
+        super(400, "VALIDATION_ERROR", message, details);
+    }
+}

--- a/backend-spring/src/main/resources/application.properties
+++ b/backend-spring/src/main/resources/application.properties
@@ -1,4 +1,28 @@
 spring.application.name=homestay-backend
-# Runs on 8080 so it coexists with the Express backend (3000) during migration (#72).
 server.port=8080
-# No datasource in Phase 0 — DB/JPA config arrives in Phase 1 (#76).
+
+# Datasource — Supabase Supavisor pooler (transaction mode). Set these in the environment.
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=1
+# Disable prepared-statement caching — required for Supavisor transaction mode.
+spring.datasource.hikari.data-source-properties.prepareThreshold=0
+spring.datasource.hikari.data-source-properties.preparedStatementCacheQueries=0
+
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.default_schema=public
+
+# Multipart body limit (mirrors Express 25 MB limit).
+spring.servlet.multipart.max-file-size=25MB
+spring.servlet.multipart.max-request-size=25MB
+
+# Omit null fields from all JSON responses (mirrors Express behavior).
+spring.jackson.default-property-inclusion=non_null
+
+# Throw NoHandlerFoundException on unmapped routes so GlobalExceptionHandler formats it.
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/AbstractContainerBaseTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/AbstractContainerBaseTest.java
@@ -1,0 +1,22 @@
+package vn.edu.hcmus.homestay;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers(disabledWithoutDocker = true)
+abstract class AbstractContainerBaseTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16").withDatabaseName("testdb");
+
+    @DynamicPropertySource
+    static void registerDatasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/HomestayBackendApplicationTests.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/HomestayBackendApplicationTests.java
@@ -4,10 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class HomestayBackendApplicationTests {
+class HomestayBackendApplicationTests extends AbstractContainerBaseTest {
 
-	@Test
-	void contextLoads() {
-	}
-
+    @Test
+    void contextLoads() {}
 }

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/ParityHarnessTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/ParityHarnessTest.java
@@ -1,0 +1,45 @@
+package vn.edu.hcmus.homestay;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Replays requests against both the Express backend and Spring Boot and diffs
+ * status + JSON. Only runs when EXPRESS_URL is set (e.g. http://localhost:3000).
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
+@EnabledIfEnvironmentVariable(named = "EXPRESS_URL", matches = ".+")
+class ParityHarnessTest extends AbstractContainerBaseTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    private static final String EXPRESS_BASE = System.getenv("EXPRESS_URL");
+
+    @Test
+    void healthParityWithExpress() {
+        ResponseEntity<String> spring =
+                rest.getForEntity("http://localhost:" + port + "/api/health", String.class);
+        ResponseEntity<String> express =
+                rest.getForEntity(EXPRESS_BASE + "/api/health", String.class);
+
+        assertThat(spring.getStatusCode()).isEqualTo(express.getStatusCode());
+        assertThat(spring.getBody()).contains("\"status\":\"OK\"");
+        assertThat(express.getBody()).contains("\"status\":\"OK\"");
+        assertThat(spring.getBody()).contains("\"timestamp\"");
+        assertThat(express.getBody()).contains("\"timestamp\"");
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/config/GlobalExceptionHandlerTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/config/GlobalExceptionHandlerTest.java
@@ -1,0 +1,120 @@
+package vn.edu.hcmus.homestay.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import vn.edu.hcmus.homestay.support.ConflictException;
+import vn.edu.hcmus.homestay.support.ForbiddenException;
+import vn.edu.hcmus.homestay.support.NotFoundException;
+import vn.edu.hcmus.homestay.support.UnauthorizedException;
+import vn.edu.hcmus.homestay.support.ValidationException;
+
+@WebMvcTest
+@Import(GlobalExceptionHandlerTest.StubController.class)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @RestController
+    static class StubController {
+
+        record Body(@NotBlank String name) {}
+
+        @GetMapping("/stub/validation")
+        void throwValidation() {
+            throw new ValidationException("bad input");
+        }
+
+        @GetMapping("/stub/unauthorized")
+        void throwUnauthorized() {
+            throw new UnauthorizedException("Invalid or missing authentication token");
+        }
+
+        @GetMapping("/stub/forbidden")
+        void throwForbidden() {
+            throw new ForbiddenException("Access denied");
+        }
+
+        @GetMapping("/stub/not-found")
+        void throwNotFound() {
+            throw new NotFoundException("Resource not found");
+        }
+
+        @GetMapping("/stub/conflict")
+        void throwConflict() {
+            throw new ConflictException("Already exists");
+        }
+
+        @PostMapping("/stub/bean-validation")
+        void beanValidation(@Valid @RequestBody Body body) {}
+    }
+
+    @Test
+    void validationErrorReturns400() throws Exception {
+        mockMvc.perform(get("/stub/validation"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void unauthorizedReturns401() throws Exception {
+        mockMvc.perform(get("/stub/unauthorized"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    void forbiddenReturns403() throws Exception {
+        mockMvc.perform(get("/stub/forbidden"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("FORBIDDEN"));
+    }
+
+    @Test
+    void notFoundReturns404() throws Exception {
+        mockMvc.perform(get("/stub/not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void conflictReturns409() throws Exception {
+        mockMvc.perform(get("/stub/conflict"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("CONFLICT"));
+    }
+
+    @Test
+    void beanValidationFailureReturns400WithDetails() throws Exception {
+        mockMvc.perform(
+                        post("/stub/bean-validation")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"name\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.error.details").isArray());
+    }
+
+    @Test
+    void unmappedRouteReturns404() throws Exception {
+        mockMvc.perform(get("/no-such-route"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/support/ApiResponseSerializationTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/support/ApiResponseSerializationTest.java
@@ -1,0 +1,72 @@
+package vn.edu.hcmus.homestay.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import tools.jackson.databind.ObjectMapper;
+
+@JsonTest
+class ApiResponseSerializationTest {
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Test
+    void successWithDataAndMessageIncludesBoth() throws Exception {
+        var response = ApiResponseBuilder.success("hello", "OK");
+        var json = mapper.writeValueAsString(response);
+        assertThat(json).contains("\"success\":true");
+        assertThat(json).contains("\"data\":\"hello\"");
+        assertThat(json).contains("\"message\":\"OK\"");
+        assertThat(json).doesNotContain("\"error\"");
+    }
+
+    @Test
+    void successOmitsNullMessage() throws Exception {
+        var response = ApiResponseBuilder.success("hello");
+        var json = mapper.writeValueAsString(response);
+        assertThat(json).doesNotContain("\"message\"");
+        assertThat(json).doesNotContain("\"error\"");
+    }
+
+    @Test
+    void successWithNullDataOmitsDataKey() throws Exception {
+        var response = ApiResponseBuilder.success(null, "Logout successful");
+        var json = mapper.writeValueAsString(response);
+        assertThat(json).doesNotContain("\"data\"");
+        assertThat(json).contains("\"message\":\"Logout successful\"");
+    }
+
+    @Test
+    void errorIncludesCodeAndMessageOmitsData() throws Exception {
+        var response = ApiResponseBuilder.error("NOT_FOUND", "Route not found");
+        var json = mapper.writeValueAsString(response);
+        assertThat(json).contains("\"success\":false");
+        assertThat(json).contains("\"code\":\"NOT_FOUND\"");
+        assertThat(json).contains("\"message\":\"Route not found\"");
+        assertThat(json).doesNotContain("\"data\"");
+        assertThat(json).doesNotContain("\"details\"");
+    }
+
+    @Test
+    void errorWithDetailsIncludesDetailsArray() throws Exception {
+        var response = ApiResponseBuilder.error(
+                "VALIDATION_ERROR", "Validation failed", List.of("field: required"));
+        var json = mapper.writeValueAsString(response);
+        assertThat(json).contains("\"details\"");
+        assertThat(json).contains("field: required");
+    }
+
+    @Test
+    void paginatedResponseSerializesCorrectly() throws Exception {
+        var pagination = new PaginatedResponse.Pagination(1, 10, 42L, 5);
+        var response = new PaginatedResponse<>(List.of("a", "b"), pagination);
+        var json = mapper.writeValueAsString(response);
+        assertThat(json).contains("\"success\":true");
+        assertThat(json).contains("\"total\":42");
+        assertThat(json).contains("\"pages\":5");
+    }
+}


### PR DESCRIPTION

## Summary

Implements Phase 1 of the Spring Boot migration (#72): cross-cutting foundation classes shared by every future feature phase. Adds the response envelope, exception hierarchy, BaseEntity, CORS + security headers, and GlobalExceptionHandler to the `backend-spring` module. Also includes slice tests (JsonTest, WebMvcTest) and a Testcontainers parity harness skeleton for future behaviour comparison against the Express backend.

## Related References

- Issue: #88
- Task doc: `docs/tasks/06-01-backend-spring-boot-migration.md`
- Related UC: all (foundation layer used by UC1–UC4)

## What Changed

- [ ] Frontend
- [x] Backend
- [ ] Database / Supabase
- [ ] CI/CD
- [ ] Documentation
- [x] Tests

## Implementation Notes

- **Response envelope** (`ApiResponse<T>`, `ApiResponseBuilder`, `PaginatedResponse`) mirrors the Express `{success, data?, message?, error?}` contract exactly. Null fields are omitted via `spring.jackson.default-property-inclusion=non_null`; `data: null` is intentionally dropped (cleaner than Express, noted for parity harness).
- **Exception hierarchy** (`AppException` + five typed subclasses) maps to the Express error codes: `VALIDATION_ERROR` (400), `UNAUTHORIZED` (401), `FORBIDDEN` (403), `NOT_FOUND` (404), `CONFLICT` (409).
- **`GlobalExceptionHandler`** handles `AppException`, bean-validation failures (`MethodArgumentNotValidException`), multipart size (`MaxUploadSizeExceededException`), unmapped routes (`NoHandlerFoundException`), and generic `Exception` (logs via SLF4J, returns opaque 500).
- **`JpaConfig`** (`@Configuration @EnableJpaAuditing`) is intentionally a separate class from `HomestayBackendApplication` — moving `@EnableJpaAuditing` off the main class prevents `JPA metamodel must not be empty` failures in `@WebMvcTest` / `@JsonTest` slices that don't load a JPA context.
- **Supavisor (transaction mode)**: `prepareThreshold=0` and `preparedStatementCacheQueries=0` disable prepared-statement caching, required by Supabase's Supavisor pooler in transaction mode.
- **`WebConfig`**: CORS uses `allowedOriginPatterns("*")` — intentional for Phase 1 (no auth yet); will be tightened to an explicit origin allowlist in Phase 2 (Spring Security). Security headers filter adds X-Content-Type-Options, X-Frame-Options, X-DNS-Prefetch-Control, and HSTS on every response.
- **Tests**: `@JsonTest` slice verifies all envelope serialisation variants; `@WebMvcTest` slice covers all `GlobalExceptionHandler` paths including unmapped route 404; `ParityHarnessTest` is skipped unless `EXPRESS_URL` env var is set (designed for migration-period comparison runs).

## Source Of Truth Check

- [ ] `docs/architecture/api-endpoints.md` — no endpoint changes (foundation only)
- [ ] `docs/architecture/database.md` — no schema changes
- [x] `docs/tasks/06-01-backend-spring-boot-migration.md` — migration task doc exists
- [ ] Relevant `docs/SUC/...` — not applicable (no business logic)
- [ ] Related README files if setup changed — `backend-spring/README.md` already covers env vars

## Screenshots / Evidence

```text
# Local verification (all gates green):
cd backend-spring
./gradlew check
# BUILD SUCCESSFUL

# Slice tests pass without Docker (Testcontainers skipped when Docker absent):
# GlobalExceptionHandlerTest — 8 tests passed
# ApiResponseSerializationTest — 6 tests passed
# HomestayBackendApplicationTests — skipped (no Docker)
```

## Checklist

- [x] I tested the changed behavior locally
- [x] I updated docs if behavior, routes, schema, or setup changed
- [x] I did not leave stale route, model, or enum names behind
- [x] I kept issue/task/docs naming consistent with the current source of truth
- [x] I added or updated tests where the change has meaningful risk

## Breaking Changes

None. Phase 1 is foundation-only; no existing endpoints or contracts are modified.

## Follow-Up Work

- Phase 2 (#77): Add Spring Security + JWT filter; tighten CORS origins; re-enforce RLS in app code
- Phase 2: Add `HttpRequestMethodNotSupportedException` (405) and `HttpMediaTypeNotSupportedException` (415) handlers to `GlobalExceptionHandler`
- Phase 10 (#85): Add `backend-spring` CI workflow (Gradle check on PR)

Closes #88