### PR TITLE
chore(backend-spring): improve open-pr skill description (#88)

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -58,10 +58,17 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)   # must not be main
 Show title, `main ← <branch>`, linked issue, labels, draft/ready, body preview.
 Get a go-ahead. Then:
 
+> ⚠️ **Always strip YAML frontmatter before `--body-file`** — passing the raw
+> `draft-pr.md` puts the `---…---` block at the top of the GitHub PR description
+> as raw text. The `awk` below strips it.
+
 ```bash
 REPO="dinhdaivu/CSC12004_Information-Systems-Analysis-and-Design"
-tmp=$(mktemp); awk 'BEGIN{fm=0}/^---[[:space:]]*$/{fm++;next}fm>=2{print}' .claude/drafts/draft-pr.md > "$tmp"
-gh pr create --repo "$REPO" --base main --head "$BRANCH" --title "<title>" --body-file "$tmp" --label "<label>"
+tmp=$(mktemp)
+awk 'BEGIN{fm=0} /^---[[:space:]]*$/{fm++; next} fm>=2{print}' \
+  .claude/drafts/draft-pr.md > "$tmp"
+gh pr create --repo "$REPO" --base main --head "$BRANCH" \
+  --title "<title>" --body-file "$tmp" --label "<label>"
 rm -f "$tmp"
 ```
 No `--reviewer` / `--assignee` unless the user explicitly asked.

--- a/backend-spring/.gitignore
+++ b/backend-spring/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Local credentials (never commit) ###
+src/main/resources/application.properties

--- a/backend-spring/README.md
+++ b/backend-spring/README.md
@@ -5,22 +5,34 @@ plan in `docs/tasks/06-01-backend-spring-boot-migration.md`. Runs **side-by-side
 with the existing `backend/` (Express) until the Phase 10 cutover; Express stays the
 deployed service for now.
 
-This is **Phase 0** (#75): scaffold only — no business logic, no database.
+Phases 0 + 1 complete: scaffold + cross-cutting foundation (response envelope, exception hierarchy, BaseEntity, CORS/security headers). No business logic yet.
 
 ## Prerequisites
 
 - **JDK 25** (the Gradle toolchain pins it; install via your JDK manager).
 - No global Gradle needed — use the wrapper (`./gradlew`).
 
+## Local environment setup
+
+Fill in your Supabase credentials directly in `src/main/resources/application.properties`:
+
+```properties
+spring.datasource.url=jdbc:postgresql://aws-0-ap-southeast-1.pooler.supabase.com:6543/postgres?sslmode=require
+spring.datasource.username=postgres.<your-project-ref>
+spring.datasource.password=<your-password>
+```
+
+`application.properties` is excluded from git tracking via `git update-index --assume-unchanged` so your credentials won't be committed. To re-enable tracking: `git update-index --no-assume-unchanged backend-spring/src/main/resources/application.properties`.
+
 ## Commands
 
 ```bash
 cd backend-spring
-./gradlew build        # compile + test + lint (spotlessCheck via `check`)
-./gradlew test         # tests only
-./gradlew check        # tests + lint
+./gradlew build         # compile + test + lint
+./gradlew test          # tests only
+./gradlew check         # tests + lint
 ./gradlew spotlessApply # auto-fix lint
-./gradlew bootRun      # run the app on http://localhost:8080
+./gradlew bootRun       # run on http://localhost:8080
 ```
 
 ## Verify


### PR DESCRIPTION
 - Response envelope (ApiResponse, ApiResponseBuilder, PaginatedResponse)
  - AppException hierarchy (Validation/Unauthorized/Forbidden/NotFound/Conflict)
  - BaseEntity with UUID PK and JPA auditing timestamps
  - GlobalExceptionHandler with SLF4J logging and HttpStatus enums
  - WebConfig: CORS + security headers filter
  - JpaConfig: moves @EnableJpaAuditing to fix web/json slice tests
  - Datasource config for Supabase Supavisor (transaction mode, no prepared stmts)
  - Testcontainers base, parity harness, and slice test suites

## Summary

<!-- Explain the goal of this PR in 2-5 sentences. -->

## Related References

- Issue:
- Task doc: `docs/tasks/...`
- Related SUC / UC:
- Figma:

## What Changed

<!-- Mark all areas touched by this PR. -->

- [ ] Frontend
- [ ] Backend
- [ ] Database / Supabase
- [ ] CI/CD
- [ ] Documentation
- [ ] Tests

## Implementation Notes

<!-- Describe important design choices, tradeoffs, or assumptions. -->

## Source Of Truth Check

<!-- Confirm any affected docs were reviewed/updated. -->

- [ ] `docs/architecture/api-endpoints.md`
- [ ] `docs/architecture/database.md`
- [ ] Relevant `docs/tasks/...`
- [ ] Relevant `docs/SUC/...`
- [ ] Related README files if setup changed

## Screenshots / Evidence

<!-- Add screenshots, rendered diagrams, logs, or other evidence when useful. -->

## Verification

<!-- Include the exact commands or checks you ran. -->

```text
Example:
npm run build
npm test
supabase db push --dry-run
```

## Checklist

- [ ] I tested the changed behavior locally
- [ ] I updated docs if behavior, routes, schema, or setup changed
- [ ] I did not leave stale route, model, or enum names behind
- [ ] I kept issue/task/docs naming consistent with the current source of truth
- [ ] I added or updated tests where the change has meaningful risk

## Breaking Changes

<!-- Write "None" if not applicable. -->

## Follow-Up Work

<!-- Optional: list items intentionally left for later. -->
