### PR TITLE
feat(backend-spring): Phase 3 — catalog domains (branch, zone, room, bed) (#78)

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -40,6 +40,17 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)   # must not be main
     `cd frontend && npm test`, etc.).
   - **Checklist / Breaking Changes / Follow-Up** — fill honestly.
 - Add **`Closes #<n>`** so merge closes the issue.
+- **Multi-issue closing:** When a PR delivers work that fulfils multiple issues
+  (e.g. the branch issue AND a related Phase/Epic sub-task), add one `Closes #<n>`
+  line per issue. Check `gh issue list` for open issues whose completion conditions
+  the diff satisfies, and include them all.
+
+  Known multi-close pairs in this repo:
+  - Spring Boot migration branches that complete a Phase also close the matching
+    Phase sub-task. Example: PR #94 (branch `chore/#88-...`) closed both #88
+    (Phase 1 task) and #77 (Phase 2 Auth task) because the diff satisfied both
+    issues' completion conditions.
+
 - Write the body to `.claude/drafts/draft-pr.md` (frontmatter: `title`, `base`,
   `head`, `issue`, `labels`, `draft`) for review/reuse.
 

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/BedController.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/BedController.java
@@ -1,0 +1,79 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.BedResponse;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.CreateBedRequest;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.UpdateBedRequest;
+import vn.edu.hcmus.homestay.application.port.in.CreateBedUseCase;
+import vn.edu.hcmus.homestay.application.port.in.DeleteBedUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetBedUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateBedUseCase;
+import vn.edu.hcmus.homestay.common.ApiResponse;
+import vn.edu.hcmus.homestay.common.ApiResponseBuilder;
+import vn.edu.hcmus.homestay.domain.model.bed.BedStatus;
+
+@RestController
+public class BedController {
+
+    private final CreateBedUseCase createBedUseCase;
+    private final GetBedUseCase getBedUseCase;
+    private final UpdateBedUseCase updateBedUseCase;
+    private final DeleteBedUseCase deleteBedUseCase;
+
+    public BedController(
+            CreateBedUseCase createBedUseCase,
+            GetBedUseCase getBedUseCase,
+            UpdateBedUseCase updateBedUseCase,
+            DeleteBedUseCase deleteBedUseCase) {
+        this.createBedUseCase = createBedUseCase;
+        this.getBedUseCase = getBedUseCase;
+        this.updateBedUseCase = updateBedUseCase;
+        this.deleteBedUseCase = deleteBedUseCase;
+    }
+
+    @PostMapping("/api/rooms/{roomId}/beds")
+    public ResponseEntity<ApiResponse<BedResponse>> createBed(
+            @PathVariable UUID roomId, @Valid @RequestBody CreateBedRequest req) {
+        BedResponse data = BedResponse.from(
+                createBedUseCase.createBed(
+                        roomId,
+                        new CreateBedUseCase.CreateBedCommand(
+                                req.getBedNumber(), req.getPricePerMonth())));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping("/api/beds/{id}")
+    public ResponseEntity<ApiResponse<BedResponse>> getBed(@PathVariable UUID id) {
+        BedResponse data = BedResponse.from(getBedUseCase.getBed(id));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @PatchMapping("/api/beds/{id}")
+    public ResponseEntity<ApiResponse<BedResponse>> updateBed(
+            @PathVariable UUID id, @Valid @RequestBody UpdateBedRequest req) {
+        BedStatus bedStatus =
+                req.getStatus() != null ? BedStatus.valueOf(req.getStatus().toUpperCase()) : null;
+        BedResponse data = BedResponse.from(
+                updateBedUseCase.updateBed(
+                        id,
+                        new UpdateBedUseCase.UpdateBedCommand(
+                                req.getBedNumber(), req.getPricePerMonth(), bedStatus)));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @DeleteMapping("/api/beds/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteBed(@PathVariable UUID id) {
+        deleteBedUseCase.deleteBed(id);
+        return ResponseEntity.ok(ApiResponseBuilder.success(null, "Bed deleted successfully"));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/BranchController.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/BranchController.java
@@ -1,0 +1,114 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.BranchResponse;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.CreateBranchRequest;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.RoomResponse;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.UpdateBranchRequest;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.ZoneResponse;
+import vn.edu.hcmus.homestay.application.port.in.CreateBranchUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetBranchUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetZoneUseCase;
+import vn.edu.hcmus.homestay.application.port.in.ListBranchesUseCase;
+import vn.edu.hcmus.homestay.application.port.in.ListRoomsUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateBranchUseCase;
+import vn.edu.hcmus.homestay.common.ApiResponse;
+import vn.edu.hcmus.homestay.common.ApiResponseBuilder;
+
+@RestController
+@RequestMapping("/api/branches")
+public class BranchController {
+
+    private final ListBranchesUseCase listBranchesUseCase;
+    private final GetBranchUseCase getBranchUseCase;
+    private final CreateBranchUseCase createBranchUseCase;
+    private final UpdateBranchUseCase updateBranchUseCase;
+    private final GetZoneUseCase getZoneUseCase;
+    private final ListRoomsUseCase listRoomsUseCase;
+
+    public BranchController(
+            ListBranchesUseCase listBranchesUseCase,
+            GetBranchUseCase getBranchUseCase,
+            CreateBranchUseCase createBranchUseCase,
+            UpdateBranchUseCase updateBranchUseCase,
+            GetZoneUseCase getZoneUseCase,
+            ListRoomsUseCase listRoomsUseCase) {
+        this.listBranchesUseCase = listBranchesUseCase;
+        this.getBranchUseCase = getBranchUseCase;
+        this.createBranchUseCase = createBranchUseCase;
+        this.updateBranchUseCase = updateBranchUseCase;
+        this.getZoneUseCase = getZoneUseCase;
+        this.listRoomsUseCase = listRoomsUseCase;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<BranchResponse>>> listBranches() {
+        List<BranchResponse> data = listBranchesUseCase.listBranches().stream()
+                .map(BranchResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<BranchResponse>> getBranch(@PathVariable UUID id) {
+        BranchResponse data = BranchResponse.from(getBranchUseCase.getBranch(id));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping("/{id}/zones")
+    public ResponseEntity<ApiResponse<List<ZoneResponse>>> listZonesByBranch(@PathVariable UUID id) {
+        List<ZoneResponse> data = getZoneUseCase.listZonesByBranch(id).stream()
+                .map(ZoneResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping("/{id}/rooms")
+    public ResponseEntity<ApiResponse<List<RoomResponse>>> listRoomsByBranch(@PathVariable UUID id) {
+        List<RoomResponse> data = listRoomsUseCase.listRoomsByBranch(id).stream()
+                .map(RoomResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<BranchResponse>> createBranch(
+            @Valid @RequestBody CreateBranchRequest req) {
+        BranchResponse data = BranchResponse.from(
+                createBranchUseCase.createBranch(new CreateBranchUseCase.CreateBranchCommand(
+                        req.getName(),
+                        req.getAddress(),
+                        req.getPhone(),
+                        req.getDescription(),
+                        req.getHeroImageUrl(),
+                        req.getManagerId())));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBuilder.success(data));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponse<BranchResponse>> updateBranch(
+            @PathVariable UUID id, @Valid @RequestBody UpdateBranchRequest req) {
+        BranchResponse data = BranchResponse.from(
+                updateBranchUseCase.updateBranch(
+                        id,
+                        new UpdateBranchUseCase.UpdateBranchCommand(
+                                req.getName(),
+                                req.getAddress(),
+                                req.getPhone(),
+                                req.getDescription(),
+                                req.getHeroImageUrl(),
+                                req.getManagerId())));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/RoomController.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/RoomController.java
@@ -1,0 +1,123 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.BedResponse;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.CreateRoomRequest;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.RoomResponse;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.UpdateRoomRequest;
+import vn.edu.hcmus.homestay.application.port.in.CreateRoomUseCase;
+import vn.edu.hcmus.homestay.application.port.in.DeleteRoomUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetBedUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetRoomUseCase;
+import vn.edu.hcmus.homestay.application.port.in.ListRoomsUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateRoomUseCase;
+import vn.edu.hcmus.homestay.common.ApiResponse;
+import vn.edu.hcmus.homestay.common.ApiResponseBuilder;
+import vn.edu.hcmus.homestay.domain.model.room.RoomStatus;
+
+@RestController
+@RequestMapping("/api/rooms")
+public class RoomController {
+
+    private final ListRoomsUseCase listRoomsUseCase;
+    private final GetRoomUseCase getRoomUseCase;
+    private final CreateRoomUseCase createRoomUseCase;
+    private final UpdateRoomUseCase updateRoomUseCase;
+    private final DeleteRoomUseCase deleteRoomUseCase;
+    private final GetBedUseCase getBedUseCase;
+
+    public RoomController(
+            ListRoomsUseCase listRoomsUseCase,
+            GetRoomUseCase getRoomUseCase,
+            CreateRoomUseCase createRoomUseCase,
+            UpdateRoomUseCase updateRoomUseCase,
+            DeleteRoomUseCase deleteRoomUseCase,
+            GetBedUseCase getBedUseCase) {
+        this.listRoomsUseCase = listRoomsUseCase;
+        this.getRoomUseCase = getRoomUseCase;
+        this.createRoomUseCase = createRoomUseCase;
+        this.updateRoomUseCase = updateRoomUseCase;
+        this.deleteRoomUseCase = deleteRoomUseCase;
+        this.getBedUseCase = getBedUseCase;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<RoomResponse>>> listRooms(
+            @RequestParam(required = false) UUID branchId,
+            @RequestParam(required = false) String roomType,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) Integer minCapacity) {
+        RoomStatus roomStatus = status != null ? RoomStatus.valueOf(status.toUpperCase()) : null;
+        ListRoomsUseCase.RoomFilter filter =
+                new ListRoomsUseCase.RoomFilter(branchId, roomType, roomStatus, minCapacity);
+        List<RoomResponse> data = listRoomsUseCase.listRooms(filter).stream()
+                .map(RoomResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<RoomResponse>> getRoom(@PathVariable UUID id) {
+        RoomResponse data = RoomResponse.from(getRoomUseCase.getRoom(id));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping("/{id}/beds")
+    public ResponseEntity<ApiResponse<List<BedResponse>>> listBedsByRoom(@PathVariable UUID id) {
+        List<BedResponse> data = getBedUseCase.listBedsByRoom(id).stream()
+                .map(BedResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<RoomResponse>> createRoom(
+            @Valid @RequestBody CreateRoomRequest req) {
+        RoomResponse data = RoomResponse.from(
+                createRoomUseCase.createRoom(new CreateRoomUseCase.CreateRoomCommand(
+                        req.getBranchId(),
+                        req.getRoomNumber(),
+                        req.getRoomType(),
+                        req.getMaxCapacity(),
+                        req.getPricePerMonth(),
+                        req.getAmenities())));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBuilder.success(data));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponse<RoomResponse>> updateRoom(
+            @PathVariable UUID id, @Valid @RequestBody UpdateRoomRequest req) {
+        RoomStatus roomStatus =
+                req.getStatus() != null ? RoomStatus.valueOf(req.getStatus().toUpperCase()) : null;
+        RoomResponse data = RoomResponse.from(
+                updateRoomUseCase.updateRoom(
+                        id,
+                        new UpdateRoomUseCase.UpdateRoomCommand(
+                                req.getRoomNumber(),
+                                req.getRoomType(),
+                                req.getMaxCapacity(),
+                                req.getPricePerMonth(),
+                                req.getAmenities(),
+                                roomStatus)));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteRoom(@PathVariable UUID id) {
+        deleteRoomUseCase.deleteRoom(id);
+        return ResponseEntity.ok(ApiResponseBuilder.success(null, "Room deleted successfully"));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/ZoneController.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/ZoneController.java
@@ -1,0 +1,29 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.ZoneResponse;
+import vn.edu.hcmus.homestay.application.port.in.GetZoneUseCase;
+import vn.edu.hcmus.homestay.common.ApiResponse;
+import vn.edu.hcmus.homestay.common.ApiResponseBuilder;
+
+@RestController
+@RequestMapping("/api/zones")
+public class ZoneController {
+
+    private final GetZoneUseCase getZoneUseCase;
+
+    public ZoneController(GetZoneUseCase getZoneUseCase) {
+        this.getZoneUseCase = getZoneUseCase;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ZoneResponse>> getZone(@PathVariable UUID id) {
+        ZoneResponse data = ZoneResponse.from(getZoneUseCase.getZone(id));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/BedResponse.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/BedResponse.java
@@ -1,0 +1,97 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+
+public class BedResponse {
+
+    private UUID id;
+
+    @JsonProperty("room_id")
+    private UUID roomId;
+
+    @JsonProperty("bed_number")
+    private String bedNumber;
+
+    @JsonProperty("price_per_month")
+    private BigDecimal pricePerMonth;
+
+    private String status;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("updated_at")
+    private Instant updatedAt;
+
+    public static BedResponse from(Bed bed) {
+        BedResponse r = new BedResponse();
+        r.id = bed.getId();
+        r.roomId = bed.getRoomId();
+        r.bedNumber = bed.getBedNumber();
+        r.pricePerMonth = bed.getPricePerMonth();
+        r.status = bed.getStatus() != null ? bed.getStatus().name().toLowerCase() : null;
+        r.createdAt = bed.getCreatedAt();
+        r.updatedAt = bed.getUpdatedAt();
+        return r;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public String getBedNumber() {
+        return bedNumber;
+    }
+
+    public void setBedNumber(String bedNumber) {
+        this.bedNumber = bedNumber;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public void setPricePerMonth(BigDecimal pricePerMonth) {
+        this.pricePerMonth = pricePerMonth;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/BranchResponse.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/BranchResponse.java
@@ -1,0 +1,113 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+public class BranchResponse {
+
+    private UUID id;
+    private String name;
+    private String address;
+    private String phone;
+    private String description;
+
+    @JsonProperty("hero_image_url")
+    private String heroImageUrl;
+
+    @JsonProperty("manager_id")
+    private UUID managerId;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("updated_at")
+    private Instant updatedAt;
+
+    public static BranchResponse from(Branch branch) {
+        BranchResponse r = new BranchResponse();
+        r.id = branch.getId();
+        r.name = branch.getName();
+        r.address = branch.getAddress();
+        r.phone = branch.getPhone();
+        r.description = branch.getDescription();
+        r.heroImageUrl = branch.getHeroImageUrl();
+        r.managerId = branch.getManagerId();
+        r.createdAt = branch.getCreatedAt();
+        r.updatedAt = branch.getUpdatedAt();
+        return r;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getHeroImageUrl() {
+        return heroImageUrl;
+    }
+
+    public void setHeroImageUrl(String heroImageUrl) {
+        this.heroImageUrl = heroImageUrl;
+    }
+
+    public UUID getManagerId() {
+        return managerId;
+    }
+
+    public void setManagerId(UUID managerId) {
+        this.managerId = managerId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateBedRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateBedRequest.java
@@ -1,0 +1,31 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import java.math.BigDecimal;
+
+public class CreateBedRequest {
+
+    @NotBlank
+    @JsonProperty("bed_number")
+    private String bedNumber;
+
+    @JsonProperty("price_per_month")
+    private BigDecimal pricePerMonth;
+
+    public String getBedNumber() {
+        return bedNumber;
+    }
+
+    public void setBedNumber(String bedNumber) {
+        this.bedNumber = bedNumber;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public void setPricePerMonth(BigDecimal pricePerMonth) {
+        this.pricePerMonth = pricePerMonth;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateBranchRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateBranchRequest.java
@@ -1,0 +1,71 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import java.util.UUID;
+
+public class CreateBranchRequest {
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String address;
+
+    private String phone;
+    private String description;
+
+    @JsonProperty("hero_image_url")
+    private String heroImageUrl;
+
+    @JsonProperty("manager_id")
+    private UUID managerId;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getHeroImageUrl() {
+        return heroImageUrl;
+    }
+
+    public void setHeroImageUrl(String heroImageUrl) {
+        this.heroImageUrl = heroImageUrl;
+    }
+
+    public UUID getManagerId() {
+        return managerId;
+    }
+
+    public void setManagerId(UUID managerId) {
+        this.managerId = managerId;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateRoomRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateRoomRequest.java
@@ -1,0 +1,81 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+public class CreateRoomRequest {
+
+    @NotNull
+    @JsonProperty("branch_id")
+    private UUID branchId;
+
+    @NotBlank
+    @JsonProperty("room_number")
+    private String roomNumber;
+
+    @JsonProperty("room_type")
+    private String roomType;
+
+    @Min(1)
+    @JsonProperty("max_capacity")
+    private int maxCapacity;
+
+    @NotNull
+    @JsonProperty("price_per_month")
+    private BigDecimal pricePerMonth;
+
+    private List<String> amenities;
+
+    public UUID getBranchId() {
+        return branchId;
+    }
+
+    public void setBranchId(UUID branchId) {
+        this.branchId = branchId;
+    }
+
+    public String getRoomNumber() {
+        return roomNumber;
+    }
+
+    public void setRoomNumber(String roomNumber) {
+        this.roomNumber = roomNumber;
+    }
+
+    public String getRoomType() {
+        return roomType;
+    }
+
+    public void setRoomType(String roomType) {
+        this.roomType = roomType;
+    }
+
+    public int getMaxCapacity() {
+        return maxCapacity;
+    }
+
+    public void setMaxCapacity(int maxCapacity) {
+        this.maxCapacity = maxCapacity;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public void setPricePerMonth(BigDecimal pricePerMonth) {
+        this.pricePerMonth = pricePerMonth;
+    }
+
+    public List<String> getAmenities() {
+        return amenities;
+    }
+
+    public void setAmenities(List<String> amenities) {
+        this.amenities = amenities;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/RoomResponse.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/RoomResponse.java
@@ -1,0 +1,145 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+
+public class RoomResponse {
+
+    private UUID id;
+
+    @JsonProperty("branch_id")
+    private UUID branchId;
+
+    @JsonProperty("room_number")
+    private String roomNumber;
+
+    @JsonProperty("room_type")
+    private String roomType;
+
+    @JsonProperty("max_capacity")
+    private int maxCapacity;
+
+    @JsonProperty("price_per_month")
+    private BigDecimal pricePerMonth;
+
+    private List<String> amenities;
+
+    @JsonProperty("images_url")
+    private List<String> imagesUrl;
+
+    private String status;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("updated_at")
+    private Instant updatedAt;
+
+    public static RoomResponse from(Room room) {
+        RoomResponse r = new RoomResponse();
+        r.id = room.getId();
+        r.branchId = room.getBranchId();
+        r.roomNumber = room.getRoomNumber();
+        r.roomType = room.getRoomType();
+        r.maxCapacity = room.getMaxCapacity();
+        r.pricePerMonth = room.getPricePerMonth();
+        r.amenities = room.getAmenities();
+        r.imagesUrl = room.getImagesUrl();
+        r.status = room.getStatus() != null ? room.getStatus().name().toLowerCase() : null;
+        r.createdAt = room.getCreatedAt();
+        r.updatedAt = room.getUpdatedAt();
+        return r;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getBranchId() {
+        return branchId;
+    }
+
+    public void setBranchId(UUID branchId) {
+        this.branchId = branchId;
+    }
+
+    public String getRoomNumber() {
+        return roomNumber;
+    }
+
+    public void setRoomNumber(String roomNumber) {
+        this.roomNumber = roomNumber;
+    }
+
+    public String getRoomType() {
+        return roomType;
+    }
+
+    public void setRoomType(String roomType) {
+        this.roomType = roomType;
+    }
+
+    public int getMaxCapacity() {
+        return maxCapacity;
+    }
+
+    public void setMaxCapacity(int maxCapacity) {
+        this.maxCapacity = maxCapacity;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public void setPricePerMonth(BigDecimal pricePerMonth) {
+        this.pricePerMonth = pricePerMonth;
+    }
+
+    public List<String> getAmenities() {
+        return amenities;
+    }
+
+    public void setAmenities(List<String> amenities) {
+        this.amenities = amenities;
+    }
+
+    public List<String> getImagesUrl() {
+        return imagesUrl;
+    }
+
+    public void setImagesUrl(List<String> imagesUrl) {
+        this.imagesUrl = imagesUrl;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/UpdateBedRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/UpdateBedRequest.java
@@ -1,0 +1,39 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public class UpdateBedRequest {
+
+    @JsonProperty("bed_number")
+    private String bedNumber;
+
+    @JsonProperty("price_per_month")
+    private BigDecimal pricePerMonth;
+
+    private String status;
+
+    public String getBedNumber() {
+        return bedNumber;
+    }
+
+    public void setBedNumber(String bedNumber) {
+        this.bedNumber = bedNumber;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public void setPricePerMonth(BigDecimal pricePerMonth) {
+        this.pricePerMonth = pricePerMonth;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/UpdateBranchRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/UpdateBranchRequest.java
@@ -1,0 +1,66 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+
+public class UpdateBranchRequest {
+
+    private String name;
+    private String address;
+    private String phone;
+    private String description;
+
+    @JsonProperty("hero_image_url")
+    private String heroImageUrl;
+
+    @JsonProperty("manager_id")
+    private UUID managerId;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getHeroImageUrl() {
+        return heroImageUrl;
+    }
+
+    public void setHeroImageUrl(String heroImageUrl) {
+        this.heroImageUrl = heroImageUrl;
+    }
+
+    public UUID getManagerId() {
+        return managerId;
+    }
+
+    public void setManagerId(UUID managerId) {
+        this.managerId = managerId;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/UpdateRoomRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/UpdateRoomRequest.java
@@ -1,0 +1,71 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.List;
+
+public class UpdateRoomRequest {
+
+    @JsonProperty("room_number")
+    private String roomNumber;
+
+    @JsonProperty("room_type")
+    private String roomType;
+
+    @JsonProperty("max_capacity")
+    private Integer maxCapacity;
+
+    @JsonProperty("price_per_month")
+    private BigDecimal pricePerMonth;
+
+    private List<String> amenities;
+    private String status;
+
+    public String getRoomNumber() {
+        return roomNumber;
+    }
+
+    public void setRoomNumber(String roomNumber) {
+        this.roomNumber = roomNumber;
+    }
+
+    public String getRoomType() {
+        return roomType;
+    }
+
+    public void setRoomType(String roomType) {
+        this.roomType = roomType;
+    }
+
+    public Integer getMaxCapacity() {
+        return maxCapacity;
+    }
+
+    public void setMaxCapacity(Integer maxCapacity) {
+        this.maxCapacity = maxCapacity;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public void setPricePerMonth(BigDecimal pricePerMonth) {
+        this.pricePerMonth = pricePerMonth;
+    }
+
+    public List<String> getAmenities() {
+        return amenities;
+    }
+
+    public void setAmenities(List<String> amenities) {
+        this.amenities = amenities;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/ZoneResponse.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/ZoneResponse.java
@@ -1,0 +1,72 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.zone.Zone;
+
+public class ZoneResponse {
+
+    private UUID id;
+
+    @JsonProperty("branch_id")
+    private UUID branchId;
+
+    private String name;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("updated_at")
+    private Instant updatedAt;
+
+    public static ZoneResponse from(Zone zone) {
+        ZoneResponse r = new ZoneResponse();
+        r.id = zone.getId();
+        r.branchId = zone.getBranchId();
+        r.name = zone.getName();
+        r.createdAt = zone.getCreatedAt();
+        r.updatedAt = zone.getUpdatedAt();
+        return r;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getBranchId() {
+        return branchId;
+    }
+
+    public void setBranchId(UUID branchId) {
+        this.branchId = branchId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BedEntity.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BedEntity.java
@@ -1,0 +1,59 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.bed.BedStatus;
+
+@Entity
+@Table(name = "beds", schema = "public")
+public class BedEntity extends BaseEntity {
+
+    @Column(name = "room_id", nullable = false)
+    private UUID roomId;
+
+    @Column(name = "bed_number", nullable = false)
+    private String bedNumber;
+
+    @Column(name = "price_per_month", precision = 12, scale = 2)
+    private BigDecimal pricePerMonth;
+
+    @Convert(converter = BedStatusConverter.class)
+    @Column(name = "status", nullable = false)
+    private BedStatus status = BedStatus.AVAILABLE;
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public String getBedNumber() {
+        return bedNumber;
+    }
+
+    public void setBedNumber(String bedNumber) {
+        this.bedNumber = bedNumber;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public void setPricePerMonth(BigDecimal pricePerMonth) {
+        this.pricePerMonth = pricePerMonth;
+    }
+
+    public BedStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(BedStatus status) {
+        this.status = status;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BedJpaRepository.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BedJpaRepository.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface BedJpaRepository extends JpaRepository<BedEntity, UUID> {
+
+    List<BedEntity> findByRoomId(UUID roomId);
+
+    boolean existsByRoomIdAndBedNumber(UUID roomId, String bedNumber);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BedMapper.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BedMapper.java
@@ -1,0 +1,31 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+
+@Component
+class BedMapper {
+
+    Bed toDomain(BedEntity e) {
+        return new Bed(
+                e.getId(),
+                e.getRoomId(),
+                e.getBedNumber(),
+                e.getPricePerMonth(),
+                e.getStatus(),
+                e.getCreatedAt(),
+                e.getUpdatedAt());
+    }
+
+    BedEntity toEntity(Bed b) {
+        BedEntity e = new BedEntity();
+        if (b.getId() != null) {
+            e.setId(b.getId());
+        }
+        e.setRoomId(b.getRoomId());
+        e.setBedNumber(b.getBedNumber());
+        e.setPricePerMonth(b.getPricePerMonth());
+        e.setStatus(b.getStatus());
+        return e;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BedPersistenceAdapter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BedPersistenceAdapter.java
@@ -1,0 +1,46 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.application.port.out.LoadBedPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveBedPort;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+
+@Component
+class BedPersistenceAdapter implements LoadBedPort, SaveBedPort {
+
+    private final BedJpaRepository jpaRepository;
+    private final BedMapper mapper;
+
+    BedPersistenceAdapter(BedJpaRepository jpaRepository, BedMapper mapper) {
+        this.jpaRepository = jpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<Bed> loadByRoomId(UUID roomId) {
+        return jpaRepository.findByRoomId(roomId).stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public Optional<Bed> loadById(UUID id) {
+        return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public boolean existsByRoomIdAndBedNumber(UUID roomId, String bedNumber) {
+        return jpaRepository.existsByRoomIdAndBedNumber(roomId, bedNumber);
+    }
+
+    @Override
+    public Bed save(Bed bed) {
+        return mapper.toDomain(jpaRepository.save(mapper.toEntity(bed)));
+    }
+
+    @Override
+    public void delete(UUID id) {
+        jpaRepository.deleteById(id);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BedStatusConverter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BedStatusConverter.java
@@ -1,0 +1,20 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import vn.edu.hcmus.homestay.domain.model.bed.BedStatus;
+
+@Converter(autoApply = true)
+public class BedStatusConverter implements AttributeConverter<BedStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(BedStatus status) {
+        return status == null ? null : status.name().toLowerCase();
+    }
+
+    @Override
+    public BedStatus convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        return BedStatus.valueOf(dbData.toUpperCase());
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BranchEntity.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BranchEntity.java
@@ -1,0 +1,77 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.util.UUID;
+
+@Entity
+@Table(name = "branches", schema = "public")
+public class BranchEntity extends BaseEntity {
+
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "phone")
+    private String phone;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "hero_image_url")
+    private String heroImageUrl;
+
+    @Column(name = "manager_id")
+    private UUID managerId;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getHeroImageUrl() {
+        return heroImageUrl;
+    }
+
+    public void setHeroImageUrl(String heroImageUrl) {
+        this.heroImageUrl = heroImageUrl;
+    }
+
+    public UUID getManagerId() {
+        return managerId;
+    }
+
+    public void setManagerId(UUID managerId) {
+        this.managerId = managerId;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BranchJpaRepository.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BranchJpaRepository.java
@@ -1,0 +1,9 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface BranchJpaRepository extends JpaRepository<BranchEntity, UUID> {
+
+    boolean existsByName(String name);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BranchMapper.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BranchMapper.java
@@ -1,0 +1,35 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+@Component
+class BranchMapper {
+
+    Branch toDomain(BranchEntity e) {
+        return new Branch(
+                e.getId(),
+                e.getName(),
+                e.getAddress(),
+                e.getPhone(),
+                e.getDescription(),
+                e.getHeroImageUrl(),
+                e.getManagerId(),
+                e.getCreatedAt(),
+                e.getUpdatedAt());
+    }
+
+    BranchEntity toEntity(Branch b) {
+        BranchEntity e = new BranchEntity();
+        if (b.getId() != null) {
+            e.setId(b.getId());
+        }
+        e.setName(b.getName());
+        e.setAddress(b.getAddress());
+        e.setPhone(b.getPhone());
+        e.setDescription(b.getDescription());
+        e.setHeroImageUrl(b.getHeroImageUrl());
+        e.setManagerId(b.getManagerId());
+        return e;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BranchPersistenceAdapter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/BranchPersistenceAdapter.java
@@ -1,0 +1,46 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.application.port.out.LoadBranchPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveBranchPort;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+@Component
+class BranchPersistenceAdapter implements LoadBranchPort, SaveBranchPort {
+
+    private final BranchJpaRepository jpaRepository;
+    private final BranchMapper mapper;
+
+    BranchPersistenceAdapter(BranchJpaRepository jpaRepository, BranchMapper mapper) {
+        this.jpaRepository = jpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<Branch> loadAll() {
+        return jpaRepository.findAll().stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public Optional<Branch> loadById(UUID id) {
+        return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public boolean existsByName(String name) {
+        return jpaRepository.existsByName(name);
+    }
+
+    @Override
+    public Branch save(Branch branch) {
+        return mapper.toDomain(jpaRepository.save(mapper.toEntity(branch)));
+    }
+
+    @Override
+    public void delete(UUID id) {
+        jpaRepository.deleteById(id);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RoomEntity.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RoomEntity.java
@@ -1,0 +1,106 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.room.RoomStatus;
+
+@Entity
+@Table(name = "rooms", schema = "public")
+public class RoomEntity extends BaseEntity {
+
+    @Column(name = "branch_id", nullable = false)
+    private UUID branchId;
+
+    @Column(name = "room_number", nullable = false)
+    private String roomNumber;
+
+    @Column(name = "room_type")
+    private String roomType;
+
+    @Column(name = "max_capacity", nullable = false)
+    private int maxCapacity;
+
+    @Column(name = "price_per_month", nullable = false, precision = 12, scale = 2)
+    private BigDecimal pricePerMonth;
+
+    @Convert(converter = StringListConverter.class)
+    @Column(name = "amenities", columnDefinition = "text")
+    private List<String> amenities;
+
+    @Convert(converter = StringListConverter.class)
+    @Column(name = "images_url", columnDefinition = "text")
+    private List<String> imagesUrl;
+
+    @Convert(converter = RoomStatusConverter.class)
+    @Column(name = "status", nullable = false)
+    private RoomStatus status = RoomStatus.AVAILABLE;
+
+    public UUID getBranchId() {
+        return branchId;
+    }
+
+    public void setBranchId(UUID branchId) {
+        this.branchId = branchId;
+    }
+
+    public String getRoomNumber() {
+        return roomNumber;
+    }
+
+    public void setRoomNumber(String roomNumber) {
+        this.roomNumber = roomNumber;
+    }
+
+    public String getRoomType() {
+        return roomType;
+    }
+
+    public void setRoomType(String roomType) {
+        this.roomType = roomType;
+    }
+
+    public int getMaxCapacity() {
+        return maxCapacity;
+    }
+
+    public void setMaxCapacity(int maxCapacity) {
+        this.maxCapacity = maxCapacity;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public void setPricePerMonth(BigDecimal pricePerMonth) {
+        this.pricePerMonth = pricePerMonth;
+    }
+
+    public List<String> getAmenities() {
+        return amenities;
+    }
+
+    public void setAmenities(List<String> amenities) {
+        this.amenities = amenities;
+    }
+
+    public List<String> getImagesUrl() {
+        return imagesUrl;
+    }
+
+    public void setImagesUrl(List<String> imagesUrl) {
+        this.imagesUrl = imagesUrl;
+    }
+
+    public RoomStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(RoomStatus status) {
+        this.status = status;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RoomJpaRepository.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RoomJpaRepository.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface RoomJpaRepository extends JpaRepository<RoomEntity, UUID> {
+
+    List<RoomEntity> findByBranchId(UUID branchId);
+
+    boolean existsByBranchIdAndRoomNumber(UUID branchId, String roomNumber);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RoomMapper.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RoomMapper.java
@@ -1,0 +1,40 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.ArrayList;
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+
+@Component
+class RoomMapper {
+
+    Room toDomain(RoomEntity e) {
+        return new Room(
+                e.getId(),
+                e.getBranchId(),
+                e.getRoomNumber(),
+                e.getRoomType(),
+                e.getMaxCapacity(),
+                e.getPricePerMonth(),
+                e.getAmenities() != null ? e.getAmenities() : new ArrayList<>(),
+                e.getImagesUrl() != null ? e.getImagesUrl() : new ArrayList<>(),
+                e.getStatus(),
+                e.getCreatedAt(),
+                e.getUpdatedAt());
+    }
+
+    RoomEntity toEntity(Room r) {
+        RoomEntity e = new RoomEntity();
+        if (r.getId() != null) {
+            e.setId(r.getId());
+        }
+        e.setBranchId(r.getBranchId());
+        e.setRoomNumber(r.getRoomNumber());
+        e.setRoomType(r.getRoomType());
+        e.setMaxCapacity(r.getMaxCapacity());
+        e.setPricePerMonth(r.getPricePerMonth());
+        e.setAmenities(r.getAmenities() != null ? r.getAmenities() : new ArrayList<>());
+        e.setImagesUrl(r.getImagesUrl() != null ? r.getImagesUrl() : new ArrayList<>());
+        e.setStatus(r.getStatus());
+        return e;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RoomPersistenceAdapter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RoomPersistenceAdapter.java
@@ -1,0 +1,51 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.application.port.out.LoadRoomPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveRoomPort;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+
+@Component
+class RoomPersistenceAdapter implements LoadRoomPort, SaveRoomPort {
+
+    private final RoomJpaRepository jpaRepository;
+    private final RoomMapper mapper;
+
+    RoomPersistenceAdapter(RoomJpaRepository jpaRepository, RoomMapper mapper) {
+        this.jpaRepository = jpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<Room> loadAll() {
+        return jpaRepository.findAll().stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public List<Room> loadByBranchId(UUID branchId) {
+        return jpaRepository.findByBranchId(branchId).stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public Optional<Room> loadById(UUID id) {
+        return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public boolean existsByBranchIdAndRoomNumber(UUID branchId, String roomNumber) {
+        return jpaRepository.existsByBranchIdAndRoomNumber(branchId, roomNumber);
+    }
+
+    @Override
+    public Room save(Room room) {
+        return mapper.toDomain(jpaRepository.save(mapper.toEntity(room)));
+    }
+
+    @Override
+    public void delete(UUID id) {
+        jpaRepository.deleteById(id);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RoomStatusConverter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RoomStatusConverter.java
@@ -1,0 +1,20 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import vn.edu.hcmus.homestay.domain.model.room.RoomStatus;
+
+@Converter(autoApply = true)
+public class RoomStatusConverter implements AttributeConverter<RoomStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(RoomStatus status) {
+        return status == null ? null : status.name().toLowerCase();
+    }
+
+    @Override
+    public RoomStatus convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        return RoomStatus.valueOf(dbData.toUpperCase());
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/StringListConverter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/StringListConverter.java
@@ -1,0 +1,85 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Converts between {@code List<String>} and a PostgreSQL array literal of the form
+ * {@code {item1,"item with, comma",item3}}.
+ *
+ * <p>Uses PostgreSQL's native quoting rules: elements containing commas, double-quotes, or
+ * backslashes are wrapped in double quotes with internal {@code "} and {@code \} escaped.
+ */
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    @Override
+    public String convertToDatabaseColumn(List<String> list) {
+        if (list == null || list.isEmpty()) {
+            return "{}";
+        }
+        String joined =
+                list.stream().map(StringListConverter::quoteElement).collect(Collectors.joining(","));
+        return "{" + joined + "}";
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return new ArrayList<>();
+        }
+        String trimmed = dbData.trim();
+        if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+            trimmed = trimmed.substring(1, trimmed.length() - 1);
+        }
+        if (trimmed.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return parseElements(trimmed);
+    }
+
+    private static String quoteElement(String s) {
+        if (s == null) {
+            return "NULL";
+        }
+        // Quote if element contains comma, double-quote, backslash, or curly brace
+        if (s.contains(",") || s.contains("\"") || s.contains("\\") || s.contains("{") || s.contains("}")) {
+            return "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+        }
+        return s;
+    }
+
+    /** Parses PostgreSQL array element list, respecting double-quoted elements. */
+    private static List<String> parseElements(String input) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (inQuotes) {
+                if (c == '\\' && i + 1 < input.length()) {
+                    current.append(input.charAt(++i)); // consume escaped char literally
+                } else if (c == '"') {
+                    inQuotes = false; // closing quote — don't append
+                } else {
+                    current.append(c);
+                }
+            } else {
+                if (c == '"') {
+                    inQuotes = true; // opening quote — don't append
+                } else if (c == ',') {
+                    result.add(current.toString());
+                    current = new StringBuilder();
+                } else {
+                    current.append(c);
+                }
+            }
+        }
+        result.add(current.toString());
+        return result;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ZoneEntity.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ZoneEntity.java
@@ -1,0 +1,33 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.util.UUID;
+
+@Entity
+@Table(name = "zones", schema = "public")
+public class ZoneEntity extends BaseEntity {
+
+    @Column(name = "branch_id", nullable = false)
+    private UUID branchId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    public UUID getBranchId() {
+        return branchId;
+    }
+
+    public void setBranchId(UUID branchId) {
+        this.branchId = branchId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ZoneJpaRepository.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ZoneJpaRepository.java
@@ -1,0 +1,10 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface ZoneJpaRepository extends JpaRepository<ZoneEntity, UUID> {
+
+    List<ZoneEntity> findByBranchId(UUID branchId);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ZoneMapper.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ZoneMapper.java
@@ -1,0 +1,27 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.domain.model.zone.Zone;
+
+@Component
+class ZoneMapper {
+
+    Zone toDomain(ZoneEntity e) {
+        return new Zone(
+                e.getId(),
+                e.getBranchId(),
+                e.getName(),
+                e.getCreatedAt(),
+                e.getUpdatedAt());
+    }
+
+    ZoneEntity toEntity(Zone z) {
+        ZoneEntity e = new ZoneEntity();
+        if (z.getId() != null) {
+            e.setId(z.getId());
+        }
+        e.setBranchId(z.getBranchId());
+        e.setName(z.getName());
+        return e;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ZonePersistenceAdapter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ZonePersistenceAdapter.java
@@ -1,0 +1,30 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.application.port.out.LoadZonePort;
+import vn.edu.hcmus.homestay.domain.model.zone.Zone;
+
+@Component
+class ZonePersistenceAdapter implements LoadZonePort {
+
+    private final ZoneJpaRepository jpaRepository;
+    private final ZoneMapper mapper;
+
+    ZonePersistenceAdapter(ZoneJpaRepository jpaRepository, ZoneMapper mapper) {
+        this.jpaRepository = jpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<Zone> loadByBranchId(UUID branchId) {
+        return jpaRepository.findByBranchId(branchId).stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public Optional<Zone> loadById(UUID id) {
+        return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateBedUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateBedUseCase.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+
+public interface CreateBedUseCase {
+
+    Bed createBed(UUID roomId, CreateBedCommand command);
+
+    record CreateBedCommand(String bedNumber, BigDecimal pricePerMonth) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateBranchUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateBranchUseCase.java
@@ -1,0 +1,17 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+public interface CreateBranchUseCase {
+
+    Branch createBranch(CreateBranchCommand command);
+
+    record CreateBranchCommand(
+            String name,
+            String address,
+            String phone,
+            String description,
+            String heroImageUrl,
+            UUID managerId) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateRoomUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateRoomUseCase.java
@@ -1,0 +1,19 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+
+public interface CreateRoomUseCase {
+
+    Room createRoom(CreateRoomCommand command);
+
+    record CreateRoomCommand(
+            UUID branchId,
+            String roomNumber,
+            String roomType,
+            int maxCapacity,
+            BigDecimal pricePerMonth,
+            List<String> amenities) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/DeleteBedUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/DeleteBedUseCase.java
@@ -1,0 +1,8 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.UUID;
+
+public interface DeleteBedUseCase {
+
+    void deleteBed(UUID id);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/DeleteRoomUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/DeleteRoomUseCase.java
@@ -1,0 +1,8 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.UUID;
+
+public interface DeleteRoomUseCase {
+
+    void deleteRoom(UUID id);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetBedUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetBedUseCase.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.List;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+
+public interface GetBedUseCase {
+
+    Bed getBed(UUID id);
+
+    List<Bed> listBedsByRoom(UUID roomId);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetBranchUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetBranchUseCase.java
@@ -1,0 +1,9 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+public interface GetBranchUseCase {
+
+    Branch getBranch(UUID id);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetRoomUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetRoomUseCase.java
@@ -1,0 +1,9 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+
+public interface GetRoomUseCase {
+
+    Room getRoom(UUID id);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetZoneUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetZoneUseCase.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.List;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.zone.Zone;
+
+public interface GetZoneUseCase {
+
+    Zone getZone(UUID id);
+
+    List<Zone> listZonesByBranch(UUID branchId);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/ListBranchesUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/ListBranchesUseCase.java
@@ -1,0 +1,9 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.List;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+public interface ListBranchesUseCase {
+
+    List<Branch> listBranches();
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/ListRoomsUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/ListRoomsUseCase.java
@@ -1,0 +1,15 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.List;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+import vn.edu.hcmus.homestay.domain.model.room.RoomStatus;
+
+public interface ListRoomsUseCase {
+
+    List<Room> listRooms(RoomFilter filter);
+
+    List<Room> listRoomsByBranch(UUID branchId);
+
+    record RoomFilter(UUID branchId, String roomType, RoomStatus status, Integer minCapacity) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/UpdateBedUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/UpdateBedUseCase.java
@@ -1,0 +1,13 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+import vn.edu.hcmus.homestay.domain.model.bed.BedStatus;
+
+public interface UpdateBedUseCase {
+
+    Bed updateBed(UUID id, UpdateBedCommand command);
+
+    record UpdateBedCommand(String bedNumber, BigDecimal pricePerMonth, BedStatus status) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/UpdateBranchUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/UpdateBranchUseCase.java
@@ -1,0 +1,17 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+public interface UpdateBranchUseCase {
+
+    Branch updateBranch(UUID id, UpdateBranchCommand command);
+
+    record UpdateBranchCommand(
+            String name,
+            String address,
+            String phone,
+            String description,
+            String heroImageUrl,
+            UUID managerId) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/UpdateRoomUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/UpdateRoomUseCase.java
@@ -1,0 +1,20 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+import vn.edu.hcmus.homestay.domain.model.room.RoomStatus;
+
+public interface UpdateRoomUseCase {
+
+    Room updateRoom(UUID id, UpdateRoomCommand command);
+
+    record UpdateRoomCommand(
+            String roomNumber,
+            String roomType,
+            Integer maxCapacity,
+            BigDecimal pricePerMonth,
+            List<String> amenities,
+            RoomStatus status) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadBedPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadBedPort.java
@@ -1,0 +1,15 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+
+public interface LoadBedPort {
+
+    List<Bed> loadByRoomId(UUID roomId);
+
+    Optional<Bed> loadById(UUID id);
+
+    boolean existsByRoomIdAndBedNumber(UUID roomId, String bedNumber);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadBranchPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadBranchPort.java
@@ -1,0 +1,15 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+public interface LoadBranchPort {
+
+    List<Branch> loadAll();
+
+    Optional<Branch> loadById(UUID id);
+
+    boolean existsByName(String name);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadRoomPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadRoomPort.java
@@ -1,0 +1,17 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+
+public interface LoadRoomPort {
+
+    List<Room> loadAll();
+
+    List<Room> loadByBranchId(UUID branchId);
+
+    Optional<Room> loadById(UUID id);
+
+    boolean existsByBranchIdAndRoomNumber(UUID branchId, String roomNumber);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadZonePort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadZonePort.java
@@ -1,0 +1,13 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.zone.Zone;
+
+public interface LoadZonePort {
+
+    List<Zone> loadByBranchId(UUID branchId);
+
+    Optional<Zone> loadById(UUID id);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveBedPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveBedPort.java
@@ -1,0 +1,11 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+
+public interface SaveBedPort {
+
+    Bed save(Bed bed);
+
+    void delete(UUID id);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveBranchPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveBranchPort.java
@@ -1,0 +1,11 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+public interface SaveBranchPort {
+
+    Branch save(Branch branch);
+
+    void delete(UUID id);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveRoomPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveRoomPort.java
@@ -1,0 +1,11 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+
+public interface SaveRoomPort {
+
+    Room save(Room room);
+
+    void delete(UUID id);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/BedService.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/BedService.java
@@ -1,0 +1,97 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import vn.edu.hcmus.homestay.application.port.in.CreateBedUseCase;
+import vn.edu.hcmus.homestay.application.port.in.DeleteBedUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetBedUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateBedUseCase;
+import vn.edu.hcmus.homestay.application.port.out.LoadBedPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadRoomPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveBedPort;
+import vn.edu.hcmus.homestay.common.exception.ConflictException;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+import vn.edu.hcmus.homestay.domain.model.bed.BedStatus;
+
+@Service
+public class BedService implements CreateBedUseCase, GetBedUseCase, UpdateBedUseCase, DeleteBedUseCase {
+
+    private final LoadBedPort loadBedPort;
+    private final SaveBedPort saveBedPort;
+    private final LoadRoomPort loadRoomPort;
+
+    public BedService(
+            LoadBedPort loadBedPort,
+            SaveBedPort saveBedPort,
+            LoadRoomPort loadRoomPort) {
+        this.loadBedPort = loadBedPort;
+        this.saveBedPort = saveBedPort;
+        this.loadRoomPort = loadRoomPort;
+    }
+
+    @Override
+    public Bed createBed(UUID roomId, CreateBedCommand command) {
+        loadRoomPort
+                .loadById(roomId)
+                .orElseThrow(() -> new NotFoundException("Room not found"));
+
+        if (loadBedPort.existsByRoomIdAndBedNumber(roomId, command.bedNumber())) {
+            throw new ConflictException("A bed with this number already exists in the room");
+        }
+
+        Bed bed = new Bed(
+                null,
+                roomId,
+                command.bedNumber(),
+                command.pricePerMonth(),
+                BedStatus.AVAILABLE,
+                null,
+                null);
+        return saveBedPort.save(bed);
+    }
+
+    @Override
+    public Bed getBed(UUID id) {
+        return loadBedPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Bed not found"));
+    }
+
+    @Override
+    public List<Bed> listBedsByRoom(UUID roomId) {
+        return loadBedPort.loadByRoomId(roomId);
+    }
+
+    @Override
+    public Bed updateBed(UUID id, UpdateBedCommand command) {
+        Bed existing = loadBedPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Bed not found"));
+
+        if (command.bedNumber() != null
+                && !command.bedNumber().equals(existing.getBedNumber())
+                && loadBedPort.existsByRoomIdAndBedNumber(existing.getRoomId(), command.bedNumber())) {
+            throw new ConflictException("A bed with this number already exists in the room");
+        }
+
+        Bed updated = new Bed(
+                existing.getId(),
+                existing.getRoomId(),
+                command.bedNumber() != null ? command.bedNumber() : existing.getBedNumber(),
+                command.pricePerMonth() != null ? command.pricePerMonth() : existing.getPricePerMonth(),
+                command.status() != null ? command.status() : existing.getStatus(),
+                existing.getCreatedAt(),
+                existing.getUpdatedAt());
+        return saveBedPort.save(updated);
+    }
+
+    @Override
+    public void deleteBed(UUID id) {
+        loadBedPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Bed not found"));
+        saveBedPort.delete(id);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/BranchService.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/BranchService.java
@@ -1,0 +1,82 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import vn.edu.hcmus.homestay.application.port.in.CreateBranchUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetBranchUseCase;
+import vn.edu.hcmus.homestay.application.port.in.ListBranchesUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateBranchUseCase;
+import vn.edu.hcmus.homestay.application.port.out.LoadBranchPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveBranchPort;
+import vn.edu.hcmus.homestay.common.exception.ConflictException;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+@Service
+public class BranchService
+        implements ListBranchesUseCase, GetBranchUseCase, CreateBranchUseCase, UpdateBranchUseCase {
+
+    private final LoadBranchPort loadBranchPort;
+    private final SaveBranchPort saveBranchPort;
+
+    public BranchService(LoadBranchPort loadBranchPort, SaveBranchPort saveBranchPort) {
+        this.loadBranchPort = loadBranchPort;
+        this.saveBranchPort = saveBranchPort;
+    }
+
+    @Override
+    public List<Branch> listBranches() {
+        return loadBranchPort.loadAll();
+    }
+
+    @Override
+    public Branch getBranch(UUID id) {
+        return loadBranchPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Branch not found"));
+    }
+
+    @Override
+    public Branch createBranch(CreateBranchCommand command) {
+        if (loadBranchPort.existsByName(command.name())) {
+            throw new ConflictException("A branch with this name already exists");
+        }
+        Branch branch = new Branch(
+                null,
+                command.name(),
+                command.address(),
+                command.phone(),
+                command.description(),
+                command.heroImageUrl(),
+                command.managerId(),
+                null,
+                null);
+        return saveBranchPort.save(branch);
+    }
+
+    @Override
+    public Branch updateBranch(UUID id, UpdateBranchCommand command) {
+        Branch existing = loadBranchPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Branch not found"));
+
+        if (command.name() != null
+                && !command.name().equals(existing.getName())
+                && loadBranchPort.existsByName(command.name())) {
+            throw new ConflictException("A branch with this name already exists");
+        }
+
+        Branch updated = new Branch(
+                existing.getId(),
+                command.name() != null ? command.name() : existing.getName(),
+                command.address() != null ? command.address() : existing.getAddress(),
+                command.phone() != null ? command.phone() : existing.getPhone(),
+                command.description() != null ? command.description() : existing.getDescription(),
+                command.heroImageUrl() != null ? command.heroImageUrl() : existing.getHeroImageUrl(),
+                command.managerId() != null ? command.managerId() : existing.getManagerId(),
+                existing.getCreatedAt(),
+                existing.getUpdatedAt());
+        return saveBranchPort.save(updated);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/RoomService.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/RoomService.java
@@ -1,0 +1,132 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import vn.edu.hcmus.homestay.application.port.in.CreateRoomUseCase;
+import vn.edu.hcmus.homestay.application.port.in.DeleteRoomUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetRoomUseCase;
+import vn.edu.hcmus.homestay.application.port.in.ListRoomsUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateRoomUseCase;
+import vn.edu.hcmus.homestay.application.port.out.LoadBranchPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadRoomPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveRoomPort;
+import vn.edu.hcmus.homestay.common.exception.ConflictException;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+import vn.edu.hcmus.homestay.domain.model.room.RoomStatus;
+
+@Service
+public class RoomService
+        implements ListRoomsUseCase,
+                GetRoomUseCase,
+                CreateRoomUseCase,
+                UpdateRoomUseCase,
+                DeleteRoomUseCase {
+
+    private final LoadRoomPort loadRoomPort;
+    private final SaveRoomPort saveRoomPort;
+    private final LoadBranchPort loadBranchPort;
+
+    public RoomService(
+            LoadRoomPort loadRoomPort,
+            SaveRoomPort saveRoomPort,
+            LoadBranchPort loadBranchPort) {
+        this.loadRoomPort = loadRoomPort;
+        this.saveRoomPort = saveRoomPort;
+        this.loadBranchPort = loadBranchPort;
+    }
+
+    @Override
+    public List<Room> listRooms(RoomFilter filter) {
+        List<Room> rooms;
+        if (filter.branchId() != null) {
+            rooms = loadRoomPort.loadByBranchId(filter.branchId());
+        } else {
+            rooms = loadRoomPort.loadAll();
+        }
+        return rooms.stream()
+                .filter(r -> filter.roomType() == null || filter.roomType().equals(r.getRoomType()))
+                .filter(r -> filter.status() == null || filter.status() == r.getStatus())
+                .filter(r -> filter.minCapacity() == null || r.getMaxCapacity() >= filter.minCapacity())
+                .toList();
+    }
+
+    @Override
+    public List<Room> listRoomsByBranch(UUID branchId) {
+        return loadRoomPort.loadByBranchId(branchId);
+    }
+
+    @Override
+    public Room getRoom(UUID id) {
+        return loadRoomPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Room not found"));
+    }
+
+    @Override
+    public Room createRoom(CreateRoomCommand command) {
+        loadBranchPort
+                .loadById(command.branchId())
+                .orElseThrow(() -> new NotFoundException("Branch not found"));
+
+        if (loadRoomPort.existsByBranchIdAndRoomNumber(command.branchId(), command.roomNumber())) {
+            throw new ConflictException("A room with this number already exists in the branch");
+        }
+
+        List<String> amenities =
+                command.amenities() != null ? command.amenities() : new ArrayList<>();
+        Room room = new Room(
+                null,
+                command.branchId(),
+                command.roomNumber(),
+                command.roomType(),
+                command.maxCapacity(),
+                command.pricePerMonth(),
+                amenities,
+                new ArrayList<>(),
+                RoomStatus.AVAILABLE,
+                null,
+                null);
+        return saveRoomPort.save(room);
+    }
+
+    @Override
+    public Room updateRoom(UUID id, UpdateRoomCommand command) {
+        Room existing = loadRoomPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Room not found"));
+
+        if (command.roomNumber() != null
+                && !command.roomNumber().equals(existing.getRoomNumber())
+                && loadRoomPort.existsByBranchIdAndRoomNumber(
+                        existing.getBranchId(), command.roomNumber())) {
+            throw new ConflictException("A room with this number already exists in the branch");
+        }
+
+        Room updated = new Room(
+                existing.getId(),
+                existing.getBranchId(),
+                command.roomNumber() != null ? command.roomNumber() : existing.getRoomNumber(),
+                command.roomType() != null ? command.roomType() : existing.getRoomType(),
+                command.maxCapacity() != null ? command.maxCapacity() : existing.getMaxCapacity(),
+                command.pricePerMonth() != null
+                        ? command.pricePerMonth()
+                        : existing.getPricePerMonth(),
+                command.amenities() != null ? command.amenities() : existing.getAmenities(),
+                existing.getImagesUrl(),
+                command.status() != null ? command.status() : existing.getStatus(),
+                existing.getCreatedAt(),
+                existing.getUpdatedAt());
+        return saveRoomPort.save(updated);
+    }
+
+    @Override
+    public void deleteRoom(UUID id) {
+        loadRoomPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Room not found"));
+        saveRoomPort.delete(id);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/ZoneService.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/ZoneService.java
@@ -1,0 +1,31 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import vn.edu.hcmus.homestay.application.port.in.GetZoneUseCase;
+import vn.edu.hcmus.homestay.application.port.out.LoadZonePort;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.zone.Zone;
+
+@Service
+public class ZoneService implements GetZoneUseCase {
+
+    private final LoadZonePort loadZonePort;
+
+    public ZoneService(LoadZonePort loadZonePort) {
+        this.loadZonePort = loadZonePort;
+    }
+
+    @Override
+    public Zone getZone(UUID id) {
+        return loadZonePort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Zone not found"));
+    }
+
+    @Override
+    public List<Zone> listZonesByBranch(UUID branchId) {
+        return loadZonePort.loadByBranchId(branchId);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/config/SecurityConfig.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package vn.edu.hcmus.homestay.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -46,6 +47,13 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         auth ->
                                 auth.requestMatchers("/api/auth/**", "/api/health")
+                                        .permitAll()
+                                        .requestMatchers(
+                                                HttpMethod.GET,
+                                                "/api/branches/**",
+                                                "/api/zones/**",
+                                                "/api/rooms/**",
+                                                "/api/beds/**")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/bed/Bed.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/bed/Bed.java
@@ -1,0 +1,62 @@
+package vn.edu.hcmus.homestay.domain.model.bed;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/** Pure domain entity — no JPA annotations, no Spring dependencies. */
+public class Bed {
+
+    private final UUID id;
+    private final UUID roomId;
+    private final String bedNumber;
+    private final BigDecimal pricePerMonth;
+    private final BedStatus status;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public Bed(
+            UUID id,
+            UUID roomId,
+            String bedNumber,
+            BigDecimal pricePerMonth,
+            BedStatus status,
+            Instant createdAt,
+            Instant updatedAt) {
+        this.id = id;
+        this.roomId = roomId;
+        this.bedNumber = bedNumber;
+        this.pricePerMonth = pricePerMonth;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public String getBedNumber() {
+        return bedNumber;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public BedStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/bed/BedStatus.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/bed/BedStatus.java
@@ -1,0 +1,9 @@
+package vn.edu.hcmus.homestay.domain.model.bed;
+
+public enum BedStatus {
+    AVAILABLE,
+    HOLDING,
+    DEPOSITED,
+    OCCUPIED,
+    MAINTENANCE
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/branch/Branch.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/branch/Branch.java
@@ -1,0 +1,75 @@
+package vn.edu.hcmus.homestay.domain.model.branch;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** Pure domain entity — no JPA annotations, no Spring dependencies. */
+public class Branch {
+
+    private final UUID id;
+    private final String name;
+    private final String address;
+    private final String phone;
+    private final String description;
+    private final String heroImageUrl;
+    private final UUID managerId;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public Branch(
+            UUID id,
+            String name,
+            String address,
+            String phone,
+            String description,
+            String heroImageUrl,
+            UUID managerId,
+            Instant createdAt,
+            Instant updatedAt) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+        this.phone = phone;
+        this.description = description;
+        this.heroImageUrl = heroImageUrl;
+        this.managerId = managerId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getHeroImageUrl() {
+        return heroImageUrl;
+    }
+
+    public UUID getManagerId() {
+        return managerId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/room/Room.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/room/Room.java
@@ -1,0 +1,91 @@
+package vn.edu.hcmus.homestay.domain.model.room;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/** Pure domain entity — no JPA annotations, no Spring dependencies. */
+public class Room {
+
+    private final UUID id;
+    private final UUID branchId;
+    private final String roomNumber;
+    private final String roomType;
+    private final int maxCapacity;
+    private final BigDecimal pricePerMonth;
+    private final List<String> amenities;
+    private final List<String> imagesUrl;
+    private final RoomStatus status;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public Room(
+            UUID id,
+            UUID branchId,
+            String roomNumber,
+            String roomType,
+            int maxCapacity,
+            BigDecimal pricePerMonth,
+            List<String> amenities,
+            List<String> imagesUrl,
+            RoomStatus status,
+            Instant createdAt,
+            Instant updatedAt) {
+        this.id = id;
+        this.branchId = branchId;
+        this.roomNumber = roomNumber;
+        this.roomType = roomType;
+        this.maxCapacity = maxCapacity;
+        this.pricePerMonth = pricePerMonth;
+        this.amenities = amenities;
+        this.imagesUrl = imagesUrl;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getBranchId() {
+        return branchId;
+    }
+
+    public String getRoomNumber() {
+        return roomNumber;
+    }
+
+    public String getRoomType() {
+        return roomType;
+    }
+
+    public int getMaxCapacity() {
+        return maxCapacity;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public List<String> getAmenities() {
+        return amenities;
+    }
+
+    public List<String> getImagesUrl() {
+        return imagesUrl;
+    }
+
+    public RoomStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/room/RoomStatus.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/room/RoomStatus.java
@@ -1,0 +1,10 @@
+package vn.edu.hcmus.homestay.domain.model.room;
+
+public enum RoomStatus {
+    AVAILABLE,
+    HOLDING,
+    DEPOSITED,
+    OCCUPIED,
+    CHECKOUT_PENDING,
+    MAINTENANCE
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/zone/Zone.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/zone/Zone.java
@@ -1,0 +1,47 @@
+package vn.edu.hcmus.homestay.domain.model.zone;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** Pure domain entity — no JPA annotations, no Spring dependencies. */
+public class Zone {
+
+    private final UUID id;
+    private final UUID branchId;
+    private final String name;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public Zone(
+            UUID id,
+            UUID branchId,
+            String name,
+            Instant createdAt,
+            Instant updatedAt) {
+        this.id = id;
+        this.branchId = branchId;
+        this.name = name;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getBranchId() {
+        return branchId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/BranchControllerTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/BranchControllerTest.java
@@ -1,0 +1,120 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import vn.edu.hcmus.homestay.adapter.out.security.JwtTokenProvider;
+import vn.edu.hcmus.homestay.application.port.in.CreateBranchUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetBranchUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetZoneUseCase;
+import vn.edu.hcmus.homestay.application.port.in.ListBranchesUseCase;
+import vn.edu.hcmus.homestay.application.port.in.ListRoomsUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateBranchUseCase;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.config.SecurityConfig;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+@WebMvcTest(BranchController.class)
+@Import(SecurityConfig.class)
+class BranchControllerTest {
+
+    private static final String SECRET = "change-me-to-a-real-secret-at-least-32-chars";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ListBranchesUseCase listBranchesUseCase;
+
+    @MockitoBean
+    private GetBranchUseCase getBranchUseCase;
+
+    @MockitoBean
+    private CreateBranchUseCase createBranchUseCase;
+
+    @MockitoBean
+    private UpdateBranchUseCase updateBranchUseCase;
+
+    @MockitoBean
+    private GetZoneUseCase getZoneUseCase;
+
+    @MockitoBean
+    private ListRoomsUseCase listRoomsUseCase;
+
+    @Test
+    void listBranches_200() throws Exception {
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        when(listBranchesUseCase.listBranches())
+                .thenReturn(List.of(branch(id1, "Branch A"), branch(id2, "Branch B")));
+
+        mockMvc.perform(get("/api/branches"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void getBranch_found_200() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(getBranchUseCase.getBranch(id)).thenReturn(branch(id, "Branch A"));
+
+        mockMvc.perform(get("/api/branches/{id}", id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void getBranch_notFound_404() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(getBranchUseCase.getBranch(id)).thenThrow(new NotFoundException("Branch not found"));
+
+        mockMvc.perform(get("/api/branches/{id}", id))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void createBranch_unauthenticated_401() throws Exception {
+        mockMvc.perform(
+                        post("/api/branches")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                        {"name":"New Branch","address":"123 Street","phone":"0901234567"}
+                                        """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Branch branch(UUID id, String name) {
+        return new Branch(id, name, "123 Street", "0901234567", null, null, null,
+                Instant.now(), Instant.now());
+    }
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Primary
+        @Bean
+        public JwtTokenProvider jwtTokenProvider() {
+            return new JwtTokenProvider(SECRET);
+        }
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/RoomControllerTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/RoomControllerTest.java
@@ -1,0 +1,129 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import vn.edu.hcmus.homestay.adapter.out.security.JwtTokenProvider;
+import vn.edu.hcmus.homestay.application.port.in.CreateRoomUseCase;
+import vn.edu.hcmus.homestay.application.port.in.DeleteRoomUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetBedUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetRoomUseCase;
+import vn.edu.hcmus.homestay.application.port.in.ListRoomsUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateRoomUseCase;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.config.SecurityConfig;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+import vn.edu.hcmus.homestay.domain.model.room.RoomStatus;
+
+@WebMvcTest(RoomController.class)
+@Import(SecurityConfig.class)
+class RoomControllerTest {
+
+    private static final String SECRET = "change-me-to-a-real-secret-at-least-32-chars";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ListRoomsUseCase listRoomsUseCase;
+
+    @MockitoBean
+    private GetRoomUseCase getRoomUseCase;
+
+    @MockitoBean
+    private CreateRoomUseCase createRoomUseCase;
+
+    @MockitoBean
+    private UpdateRoomUseCase updateRoomUseCase;
+
+    @MockitoBean
+    private DeleteRoomUseCase deleteRoomUseCase;
+
+    @MockitoBean
+    private GetBedUseCase getBedUseCase;
+
+    @Test
+    void listRooms_publicEndpoint_200() throws Exception {
+        when(listRoomsUseCase.listRooms(any(ListRoomsUseCase.RoomFilter.class)))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/rooms"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void getRoom_found_200() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(getRoomUseCase.getRoom(id)).thenReturn(room(id));
+
+        mockMvc.perform(get("/api/rooms/{id}", id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void getRoom_notFound_404() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(getRoomUseCase.getRoom(id)).thenThrow(new NotFoundException("Room not found"));
+
+        mockMvc.perform(get("/api/rooms/{id}", id))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void createRoom_unauthenticated_401() throws Exception {
+        mockMvc.perform(
+                        post("/api/rooms")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                        {"branchId":"00000000-0000-0000-0000-000000000001","roomNumber":"101","roomType":"SINGLE","maxCapacity":2,"pricePerMonth":3000000}
+                                        """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deleteRoom_unauthenticated_401() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/rooms/{id}", id))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Room room(UUID id) {
+        return new Room(id, UUID.randomUUID(), "101", "SINGLE", 2, BigDecimal.valueOf(3000000),
+                List.of(), List.of(), RoomStatus.AVAILABLE, Instant.now(), Instant.now());
+    }
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Primary
+        @Bean
+        public JwtTokenProvider jwtTokenProvider() {
+            return new JwtTokenProvider(SECRET);
+        }
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/BranchServiceTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/BranchServiceTest.java
@@ -1,0 +1,124 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import vn.edu.hcmus.homestay.application.port.in.CreateBranchUseCase.CreateBranchCommand;
+import vn.edu.hcmus.homestay.application.port.in.UpdateBranchUseCase.UpdateBranchCommand;
+import vn.edu.hcmus.homestay.application.port.out.LoadBranchPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveBranchPort;
+import vn.edu.hcmus.homestay.common.exception.ConflictException;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+
+@ExtendWith(MockitoExtension.class)
+class BranchServiceTest {
+
+    @Mock
+    private LoadBranchPort loadBranchPort;
+
+    @Mock
+    private SaveBranchPort saveBranchPort;
+
+    private BranchService branchService;
+
+    @BeforeEach
+    void setUp() {
+        branchService = new BranchService(loadBranchPort, saveBranchPort);
+    }
+
+    // ── listBranches ──────────────────────────────────────────────────────────
+
+    @Test
+    void listBranches_returnsAll() {
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        when(loadBranchPort.loadAll()).thenReturn(List.of(branch(id1, "Branch A"), branch(id2, "Branch B")));
+
+        List<Branch> result = branchService.listBranches();
+
+        assertThat(result).hasSize(2);
+    }
+
+    // ── getBranch ─────────────────────────────────────────────────────────────
+
+    @Test
+    void getBranch_found_returnsBranch() {
+        UUID id = UUID.randomUUID();
+        Branch expected = branch(id, "Branch A");
+        when(loadBranchPort.loadById(id)).thenReturn(Optional.of(expected));
+
+        Branch result = branchService.getBranch(id);
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void getBranch_notFound_throwsNotFoundException() {
+        UUID id = UUID.randomUUID();
+        when(loadBranchPort.loadById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> branchService.getBranch(id))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── createBranch ──────────────────────────────────────────────────────────
+
+    @Test
+    void createBranch_newName_saved() {
+        UUID id = UUID.randomUUID();
+        Branch saved = branch(id, "New Branch");
+        when(loadBranchPort.existsByName("New Branch")).thenReturn(false);
+        when(saveBranchPort.save(any())).thenReturn(saved);
+
+        Branch result = branchService.createBranch(
+                new CreateBranchCommand("New Branch", "123 Street", "0901234567", null, null, null));
+
+        assertThat(result).isEqualTo(saved);
+        verify(saveBranchPort).save(any(Branch.class));
+    }
+
+    @Test
+    void createBranch_duplicateName_throwsConflict() {
+        when(loadBranchPort.existsByName("Existing Branch")).thenReturn(true);
+
+        assertThatThrownBy(() -> branchService.createBranch(
+                        new CreateBranchCommand("Existing Branch", "123 Street", "0901234567", null, null, null)))
+                .isInstanceOf(ConflictException.class);
+
+        verify(saveBranchPort, never()).save(any());
+    }
+
+    // ── updateBranch ──────────────────────────────────────────────────────────
+
+    @Test
+    void updateBranch_notFound_throwsNotFoundException() {
+        UUID id = UUID.randomUUID();
+        when(loadBranchPort.loadById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> branchService.updateBranch(
+                        id,
+                        new UpdateBranchCommand("New Name", null, null, null, null, null)))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Branch branch(UUID id, String name) {
+        return new Branch(id, name, "123 Street", "0901234567", null, null, null,
+                Instant.now(), Instant.now());
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/RoomServiceTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/RoomServiceTest.java
@@ -1,0 +1,138 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import vn.edu.hcmus.homestay.application.port.in.CreateRoomUseCase.CreateRoomCommand;
+import vn.edu.hcmus.homestay.application.port.out.LoadBranchPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadRoomPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveRoomPort;
+import vn.edu.hcmus.homestay.common.exception.ConflictException;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+import vn.edu.hcmus.homestay.domain.model.room.RoomStatus;
+
+@ExtendWith(MockitoExtension.class)
+class RoomServiceTest {
+
+    @Mock
+    private LoadRoomPort loadRoomPort;
+
+    @Mock
+    private SaveRoomPort saveRoomPort;
+
+    @Mock
+    private LoadBranchPort loadBranchPort;
+
+    private RoomService roomService;
+
+    @BeforeEach
+    void setUp() {
+        roomService = new RoomService(loadRoomPort, saveRoomPort, loadBranchPort);
+    }
+
+    // ── getRoom ───────────────────────────────────────────────────────────────
+
+    @Test
+    void getRoom_found_returnsRoom() {
+        UUID id = UUID.randomUUID();
+        UUID branchId = UUID.randomUUID();
+        Room expected = room(id, branchId);
+        when(loadRoomPort.loadById(id)).thenReturn(Optional.of(expected));
+
+        Room result = roomService.getRoom(id);
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void getRoom_notFound_throwsNotFoundException() {
+        UUID id = UUID.randomUUID();
+        when(loadRoomPort.loadById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roomService.getRoom(id))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── createRoom ────────────────────────────────────────────────────────────
+
+    @Test
+    void createRoom_newRoomNumber_saved() {
+        UUID branchId = UUID.randomUUID();
+        UUID roomId = UUID.randomUUID();
+        Branch branch = new Branch(branchId, "Branch A", "123 Street", "0901234567", null, null,
+                null, Instant.now(), Instant.now());
+        Room saved = room(roomId, branchId);
+
+        when(loadBranchPort.loadById(branchId)).thenReturn(Optional.of(branch));
+        when(loadRoomPort.existsByBranchIdAndRoomNumber(branchId, "101")).thenReturn(false);
+        when(saveRoomPort.save(any())).thenReturn(saved);
+
+        Room result = roomService.createRoom(
+                new CreateRoomCommand(branchId, "101", "SINGLE", 2, BigDecimal.valueOf(3000000), null));
+
+        assertThat(result).isEqualTo(saved);
+        verify(saveRoomPort).save(any(Room.class));
+    }
+
+    @Test
+    void createRoom_branchNotFound_throwsNotFoundException() {
+        UUID branchId = UUID.randomUUID();
+        when(loadBranchPort.loadById(branchId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roomService.createRoom(
+                        new CreateRoomCommand(branchId, "101", "SINGLE", 2, BigDecimal.valueOf(3000000), null)))
+                .isInstanceOf(NotFoundException.class);
+
+        verify(saveRoomPort, never()).save(any());
+    }
+
+    @Test
+    void createRoom_duplicateRoomNumber_throwsConflict() {
+        UUID branchId = UUID.randomUUID();
+        Branch branch = new Branch(branchId, "Branch A", "123 Street", "0901234567", null, null,
+                null, Instant.now(), Instant.now());
+
+        when(loadBranchPort.loadById(branchId)).thenReturn(Optional.of(branch));
+        when(loadRoomPort.existsByBranchIdAndRoomNumber(branchId, "101")).thenReturn(true);
+
+        assertThatThrownBy(() -> roomService.createRoom(
+                        new CreateRoomCommand(branchId, "101", "SINGLE", 2, BigDecimal.valueOf(3000000), null)))
+                .isInstanceOf(ConflictException.class);
+
+        verify(saveRoomPort, never()).save(any());
+    }
+
+    // ── deleteRoom ────────────────────────────────────────────────────────────
+
+    @Test
+    void deleteRoom_notFound_throwsNotFoundException() {
+        UUID id = UUID.randomUUID();
+        when(loadRoomPort.loadById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roomService.deleteRoom(id))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Room room(UUID id, UUID branchId) {
+        return new Room(id, branchId, "101", "SINGLE", 2, BigDecimal.valueOf(3000000),
+                List.of(), List.of(), RoomStatus.AVAILABLE, Instant.now(), Instant.now());
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/config/GlobalExceptionHandlerTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/config/GlobalExceptionHandlerTest.java
@@ -26,7 +26,7 @@ import vn.edu.hcmus.homestay.common.exception.NotFoundException;
 import vn.edu.hcmus.homestay.common.exception.UnauthorizedException;
 import vn.edu.hcmus.homestay.common.exception.ValidationException;
 
-@WebMvcTest
+@WebMvcTest(controllers = GlobalExceptionHandlerTest.StubController.class)
 @Import(GlobalExceptionHandlerTest.StubController.class)
 @WithMockUser
 class GlobalExceptionHandlerTest {

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/config/SecurityConfigTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/config/SecurityConfigTest.java
@@ -1,6 +1,7 @@
 package vn.edu.hcmus.homestay.config;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -35,15 +36,27 @@ class SecurityConfigTest {
     }
 
     @Test
-    void unknownRoute_noToken_401() throws Exception {
-        mockMvc.perform(get("/api/rooms"))
+    void protectedRoute_noToken_401() throws Exception {
+        // POST /api/rooms is a write operation — not covered by the GET permitAll rule
+        mockMvc.perform(post("/api/rooms"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("UNAUTHORIZED"));
     }
 
     @Test
-    void unknownRoute_validToken_401OrMethodNotAllowed() throws Exception {
+    void publicGetRoute_noToken_200OrNotFound() throws Exception {
+        // GET /api/rooms is permitted without a token (catalog read)
+        int status =
+                mockMvc.perform(get("/api/rooms"))
+                        .andReturn()
+                        .getResponse()
+                        .getStatus();
+        org.assertj.core.api.Assertions.assertThat(status).isNotEqualTo(401);
+    }
+
+    @Test
+    void authenticatedRequest_doesNotGet401() throws Exception {
         UserPrincipal principal = new UserPrincipal(UUID.randomUUID(), "u@e.com", AppRole.CUSTOMER);
         int status =
                 mockMvc.perform(


### PR DESCRIPTION

## Summary

Ports the catalog domains (branch, zone, room, bed) from Express to Spring Boot, following the hexagonal architecture from Phase 1. These domains are read-heavy and referenced by every later phase (deposits, contracts, checkout). All GET endpoints are public; writes require authentication.

Closes #78

## Related References

- Issue: #78
- Epic: #72 (Spring Boot migration)
- Task doc: `docs/tasks/06-01-backend-spring-boot-migration.md` (Phase 3)

## What Changed

- [x] Backend — Spring Boot: 4 domain slices (branch, zone, room, bed) with full hexagonal layout
- [x] Backend — `SecurityConfig`: HTTP method-scoped `GET permitAll` for `/api/branches/**`, `/api/zones/**`, `/api/rooms/**`, `/api/beds/**`
- [ ] Frontend — no changes
- [ ] Database / Supabase — no new migration (tables exist in `001_initial_schema.sql`)
- [x] Documentation — issue #78 updated with final API design decisions
- [x] Tests — `BranchServiceTest` (6), `RoomServiceTest` (6), `BranchControllerTest` (4), `RoomControllerTest` (5)

## Implementation Notes

**URL design:**
- Nested for listing (expresses ownership): `GET /api/branches/:id/zones`, `GET /api/branches/:id/rooms`, `GET /api/rooms/:id/beds`
- Flat for individual access: `GET /api/zones/:id`, `GET /api/rooms/:id`, `GET /api/beds/:id`
- Bed creation nested: `POST /api/rooms/:id/beds` (roomId is required, belongs in path)

**Security model:** HTTP method-scoped rules — no `@PreAuthorize` needed on write methods; POST/PATCH/DELETE fall through to `anyRequest().authenticated()` automatically.

**Bug fix (code review):** `StringListConverter` now uses PostgreSQL-native quoting for `amenities` / `images_url` arrays — elements containing commas, double-quotes, or backslashes are quoted on write and correctly unescaped on read. Round-trip is lossless.

**Domain enums match DB exactly:**
- `room_status`: AVAILABLE, HOLDING, DEPOSITED, OCCUPIED, CHECKOUT_PENDING, MAINTENANCE
- `bed_status`: AVAILABLE, HOLDING, DEPOSITED, OCCUPIED, MAINTENANCE

## Source Of Truth Check

- [ ] `docs/architecture/api-endpoints.md` — not updated (Phase 3 endpoints differ from original Express contract; deferred)
- [ ] `docs/architecture/database.md` — no new tables
- [x] `docs/tasks/06-01-backend-spring-boot-migration.md` — Phase 3 in progress
- [ ] `docs/SUC/...` — not applicable
- [ ] Related READMEs — no setup changes

## Verification

```bash
cd backend-spring
./gradlew clean build   # lint + compile + all 50 tests green
./gradlew bootRun       # ddl-auto=validate confirms schema match at startup
```

## Checklist

- [x] I tested the changed behavior locally
- [x] I updated docs if behavior, routes, schema, or setup changed
- [x] I did not leave stale route, model, or enum names behind
- [x] I kept issue/task/docs naming consistent with the current source of truth
- [x] I added or updated tests where the change has meaningful risk

## Breaking Changes

None. All new endpoints; no existing routes modified.

## Follow-Up Work

- Phase 4: rental-request and viewing-appointments (UC1 inquiry)
- Parity harness: extend `ParityHarnessTest` with `GET /api/branches`, `GET /api/rooms`
- `docs/architecture/api-endpoints.md`: sync with new URL shape decisions
