### PR TITLE
feat(backend-spring): Phase 4 — UC1 inquiry (rental-request, viewing-appointments) (#79)

### DIFF
--- a/backend-spring/README.md
+++ b/backend-spring/README.md
@@ -5,8 +5,10 @@ plan in `docs/tasks/06-01-backend-spring-boot-migration.md`. Runs **side-by-side
 with the existing `backend/` (Express) until the Phase 10 cutover; Express stays the
 deployed service for now.
 
-Phases 0 + 1 complete: scaffold, clean architecture (hexagonal/ports-and-adapters),
-cross-cutting foundation, and auth endpoints (register / login / me / change-password).
+**Phases 0–4 complete:**
+- Phase 0+1: scaffold, clean architecture (hexagonal/ports-and-adapters), auth endpoints
+- Phase 3: catalog domains — branch, zone, room, bed (PR #96)
+- Phase 4: UC1 inquiry — rental-request, viewing-appointments (PR #97)
 
 ## Prerequisites
 
@@ -65,10 +67,13 @@ src/main/java/vn/edu/hcmus/homestay/
 │
 ├── domain/                        ← innermost ring — pure Java, zero framework deps
 │   └── model/
-│       └── user/
-│           ├── User.java          immutable domain entity
-│           ├── AppRole.java       enum: CUSTOMER | SALE | ACCOUNTANT | MANAGER | ADMIN
-│           └── UserStatus.java    enum: ACTIVE | INACTIVE | BANNED
+│       ├── user/        User, AppRole, UserStatus
+│       ├── branch/      Branch
+│       ├── zone/        Zone
+│       ├── room/        Room, RoomStatus
+│       ├── bed/         Bed, BedStatus
+│       ├── rental/      RentalRequest, RentalRequestStatus (+ VALID_TRANSITIONS map)
+│       └── viewing/     ViewingAppointment, ViewingAppointmentStatus
 │
 ├── application/                   ← use-cases and ports
 │   ├── port/

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/RentalRequestController.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/RentalRequestController.java
@@ -1,0 +1,101 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import vn.edu.hcmus.homestay.adapter.in.security.UserPrincipal;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.CreateRentalRequestRequest;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.RentalRequestResponse;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.UpdateRentalRequestStatusRequest;
+import vn.edu.hcmus.homestay.application.port.in.CreateRentalRequestUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetRentalRequestUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateRentalRequestStatusUseCase;
+import vn.edu.hcmus.homestay.common.ApiResponse;
+import vn.edu.hcmus.homestay.common.ApiResponseBuilder;
+
+@RestController
+@RequestMapping("/api/rental-requests")
+@PreAuthorize("isAuthenticated()")
+public class RentalRequestController {
+
+    private final CreateRentalRequestUseCase createRentalRequestUseCase;
+    private final GetRentalRequestUseCase getRentalRequestUseCase;
+    private final UpdateRentalRequestStatusUseCase updateRentalRequestStatusUseCase;
+
+    public RentalRequestController(
+            CreateRentalRequestUseCase createRentalRequestUseCase,
+            GetRentalRequestUseCase getRentalRequestUseCase,
+            UpdateRentalRequestStatusUseCase updateRentalRequestStatusUseCase) {
+        this.createRentalRequestUseCase = createRentalRequestUseCase;
+        this.getRentalRequestUseCase = getRentalRequestUseCase;
+        this.updateRentalRequestStatusUseCase = updateRentalRequestStatusUseCase;
+    }
+
+    // Declared BEFORE /{id} to avoid path collision with literal "my-requests"
+    @GetMapping("/my-requests")
+    public ResponseEntity<ApiResponse<List<RentalRequestResponse>>> getMyRentalRequests(
+            @AuthenticationPrincipal UserPrincipal principal) {
+        List<RentalRequestResponse> data = getRentalRequestUseCase
+                .getMyRentalRequests(principal.getId())
+                .stream()
+                .map(RentalRequestResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('SALE','MANAGER','ADMIN')")
+    public ResponseEntity<ApiResponse<List<RentalRequestResponse>>> getAllRentalRequests() {
+        List<RentalRequestResponse> data = getRentalRequestUseCase.getAllRentalRequests()
+                .stream()
+                .map(RentalRequestResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<RentalRequestResponse>> getRentalRequest(
+            @PathVariable UUID id, @AuthenticationPrincipal UserPrincipal principal) {
+        RentalRequestResponse data = RentalRequestResponse.from(
+                getRentalRequestUseCase.getRentalRequest(id, principal));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<RentalRequestResponse>> createRentalRequest(
+            @Valid @RequestBody CreateRentalRequestRequest req,
+            @AuthenticationPrincipal UserPrincipal principal) {
+        RentalRequestResponse data = RentalRequestResponse.from(
+                createRentalRequestUseCase.createRentalRequest(
+                        new CreateRentalRequestUseCase.CreateRentalRequestCommand(
+                                principal.getId(),
+                                req.getBranchId(),
+                                req.getRoomId(),
+                                req.getBedId(),
+                                req.getPreferredRoomType(),
+                                req.getBudgetMin(),
+                                req.getBudgetMax(),
+                                req.getPeopleCount(),
+                                req.getNote())));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBuilder.success(data));
+    }
+
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<ApiResponse<RentalRequestResponse>> updateStatus(
+            @PathVariable UUID id, @Valid @RequestBody UpdateRentalRequestStatusRequest req) {
+        RentalRequestResponse data = RentalRequestResponse.from(
+                updateRentalRequestStatusUseCase.updateStatus(id, req.getStatus()));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/ViewingAppointmentController.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/ViewingAppointmentController.java
@@ -1,0 +1,105 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.CreateViewingAppointmentRequest;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.RecordOutcomeRequest;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.UpdateViewingAppointmentRequest;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.ViewingAppointmentResponse;
+import vn.edu.hcmus.homestay.application.port.in.CreateViewingAppointmentUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetViewingAppointmentUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateViewingAppointmentUseCase;
+import vn.edu.hcmus.homestay.common.ApiResponse;
+import vn.edu.hcmus.homestay.common.ApiResponseBuilder;
+
+@RestController
+@RequestMapping("/api/viewing-appointments")
+@PreAuthorize("hasAnyRole('SALE','MANAGER','ADMIN')")
+public class ViewingAppointmentController {
+
+    private final CreateViewingAppointmentUseCase createViewingAppointmentUseCase;
+    private final GetViewingAppointmentUseCase getViewingAppointmentUseCase;
+    private final UpdateViewingAppointmentUseCase updateViewingAppointmentUseCase;
+
+    public ViewingAppointmentController(
+            CreateViewingAppointmentUseCase createViewingAppointmentUseCase,
+            GetViewingAppointmentUseCase getViewingAppointmentUseCase,
+            UpdateViewingAppointmentUseCase updateViewingAppointmentUseCase) {
+        this.createViewingAppointmentUseCase = createViewingAppointmentUseCase;
+        this.getViewingAppointmentUseCase = getViewingAppointmentUseCase;
+        this.updateViewingAppointmentUseCase = updateViewingAppointmentUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ViewingAppointmentResponse>> createViewingAppointment(
+            @Valid @RequestBody CreateViewingAppointmentRequest req) {
+        ViewingAppointmentResponse data = ViewingAppointmentResponse.from(
+                createViewingAppointmentUseCase.createViewingAppointment(
+                        new CreateViewingAppointmentUseCase.CreateViewingAppointmentCommand(
+                                req.getRentalRequestId(),
+                                req.getCustomerId(),
+                                req.getSaleId(),
+                                req.getRoomId(),
+                                req.getBedId(),
+                                req.getScheduledAt())));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ViewingAppointmentResponse>>> getAllViewingAppointments() {
+        List<ViewingAppointmentResponse> data = getViewingAppointmentUseCase.getAllViewingAppointments()
+                .stream()
+                .map(ViewingAppointmentResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ViewingAppointmentResponse>> getViewingAppointment(
+            @PathVariable UUID id) {
+        ViewingAppointmentResponse data = ViewingAppointmentResponse.from(
+                getViewingAppointmentUseCase.getViewingAppointment(id));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @PatchMapping("/{id}/cancel")
+    public ResponseEntity<ApiResponse<ViewingAppointmentResponse>> cancelAppointment(
+            @PathVariable UUID id) {
+        ViewingAppointmentResponse data = ViewingAppointmentResponse.from(
+                updateViewingAppointmentUseCase.cancelAppointment(id));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @PatchMapping("/{id}/outcome")
+    public ResponseEntity<ApiResponse<ViewingAppointmentResponse>> recordOutcome(
+            @PathVariable UUID id, @Valid @RequestBody RecordOutcomeRequest req) {
+        ViewingAppointmentResponse data = ViewingAppointmentResponse.from(
+                updateViewingAppointmentUseCase.recordOutcome(
+                        id,
+                        new UpdateViewingAppointmentUseCase.RecordOutcomeCommand(
+                                req.getResultNote(), req.getStatus())));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponse<ViewingAppointmentResponse>> updateAppointment(
+            @PathVariable UUID id, @Valid @RequestBody UpdateViewingAppointmentRequest req) {
+        ViewingAppointmentResponse data = ViewingAppointmentResponse.from(
+                updateViewingAppointmentUseCase.updateAppointment(
+                        id,
+                        new UpdateViewingAppointmentUseCase.UpdateAppointmentCommand(
+                                req.getSaleId(), req.getRoomId(), req.getBedId(), req.getScheduledAt())));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateRentalRequestRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateRentalRequestRequest.java
@@ -1,0 +1,97 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public class CreateRentalRequestRequest {
+
+    @JsonProperty("branch_id")
+    private UUID branchId;
+
+    @JsonProperty("room_id")
+    private UUID roomId;
+
+    @JsonProperty("bed_id")
+    private UUID bedId;
+
+    @JsonProperty("preferred_room_type")
+    private String preferredRoomType;
+
+    @JsonProperty("budget_min")
+    private BigDecimal budgetMin;
+
+    @JsonProperty("budget_max")
+    private BigDecimal budgetMax;
+
+    @Min(1)
+    @JsonProperty("people_count")
+    private int peopleCount = 1;
+
+    private String note;
+
+    public UUID getBranchId() {
+        return branchId;
+    }
+
+    public void setBranchId(UUID branchId) {
+        this.branchId = branchId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public void setBedId(UUID bedId) {
+        this.bedId = bedId;
+    }
+
+    public String getPreferredRoomType() {
+        return preferredRoomType;
+    }
+
+    public void setPreferredRoomType(String preferredRoomType) {
+        this.preferredRoomType = preferredRoomType;
+    }
+
+    public BigDecimal getBudgetMin() {
+        return budgetMin;
+    }
+
+    public void setBudgetMin(BigDecimal budgetMin) {
+        this.budgetMin = budgetMin;
+    }
+
+    public BigDecimal getBudgetMax() {
+        return budgetMax;
+    }
+
+    public void setBudgetMax(BigDecimal budgetMax) {
+        this.budgetMax = budgetMax;
+    }
+
+    public int getPeopleCount() {
+        return peopleCount;
+    }
+
+    public void setPeopleCount(int peopleCount) {
+        this.peopleCount = peopleCount;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public void setNote(String note) {
+        this.note = note;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateViewingAppointmentRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateViewingAppointmentRequest.java
@@ -1,0 +1,78 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.UUID;
+
+public class CreateViewingAppointmentRequest {
+
+    @NotNull
+    @JsonProperty("rental_request_id")
+    private UUID rentalRequestId;
+
+    @NotNull
+    @JsonProperty("customer_id")
+    private UUID customerId;
+
+    @JsonProperty("sale_id")
+    private UUID saleId;
+
+    @JsonProperty("room_id")
+    private UUID roomId;
+
+    @JsonProperty("bed_id")
+    private UUID bedId;
+
+    @NotNull
+    @JsonProperty("scheduled_at")
+    private Instant scheduledAt;
+
+    public UUID getRentalRequestId() {
+        return rentalRequestId;
+    }
+
+    public void setRentalRequestId(UUID rentalRequestId) {
+        this.rentalRequestId = rentalRequestId;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+        this.customerId = customerId;
+    }
+
+    public UUID getSaleId() {
+        return saleId;
+    }
+
+    public void setSaleId(UUID saleId) {
+        this.saleId = saleId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public void setBedId(UUID bedId) {
+        this.bedId = bedId;
+    }
+
+    public Instant getScheduledAt() {
+        return scheduledAt;
+    }
+
+    public void setScheduledAt(Instant scheduledAt) {
+        this.scheduledAt = scheduledAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/RecordOutcomeRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/RecordOutcomeRequest.java
@@ -1,0 +1,30 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointmentStatus;
+
+public class RecordOutcomeRequest {
+
+    @JsonProperty("result_note")
+    private String resultNote;
+
+    @NotNull
+    private ViewingAppointmentStatus status;
+
+    public String getResultNote() {
+        return resultNote;
+    }
+
+    public void setResultNote(String resultNote) {
+        this.resultNote = resultNote;
+    }
+
+    public ViewingAppointmentStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ViewingAppointmentStatus status) {
+        this.status = status;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/RentalRequestResponse.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/RentalRequestResponse.java
@@ -1,0 +1,168 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+
+public class RentalRequestResponse {
+
+    private UUID id;
+
+    @JsonProperty("customer_id")
+    private UUID customerId;
+
+    @JsonProperty("branch_id")
+    private UUID branchId;
+
+    @JsonProperty("room_id")
+    private UUID roomId;
+
+    @JsonProperty("bed_id")
+    private UUID bedId;
+
+    @JsonProperty("preferred_room_type")
+    private String preferredRoomType;
+
+    @JsonProperty("budget_min")
+    private BigDecimal budgetMin;
+
+    @JsonProperty("budget_max")
+    private BigDecimal budgetMax;
+
+    @JsonProperty("people_count")
+    private int peopleCount;
+
+    private String note;
+
+    private String status;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("updated_at")
+    private Instant updatedAt;
+
+    public static RentalRequestResponse from(RentalRequest req) {
+        RentalRequestResponse r = new RentalRequestResponse();
+        r.id = req.getId();
+        r.customerId = req.getCustomerId();
+        r.branchId = req.getBranchId();
+        r.roomId = req.getRoomId();
+        r.bedId = req.getBedId();
+        r.preferredRoomType = req.getPreferredRoomType();
+        r.budgetMin = req.getBudgetMin();
+        r.budgetMax = req.getBudgetMax();
+        r.peopleCount = req.getPeopleCount();
+        r.note = req.getNote();
+        r.status = req.getStatus() != null ? req.getStatus().name().toLowerCase() : null;
+        r.createdAt = req.getCreatedAt();
+        r.updatedAt = req.getUpdatedAt();
+        return r;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+        this.customerId = customerId;
+    }
+
+    public UUID getBranchId() {
+        return branchId;
+    }
+
+    public void setBranchId(UUID branchId) {
+        this.branchId = branchId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public void setBedId(UUID bedId) {
+        this.bedId = bedId;
+    }
+
+    public String getPreferredRoomType() {
+        return preferredRoomType;
+    }
+
+    public void setPreferredRoomType(String preferredRoomType) {
+        this.preferredRoomType = preferredRoomType;
+    }
+
+    public BigDecimal getBudgetMin() {
+        return budgetMin;
+    }
+
+    public void setBudgetMin(BigDecimal budgetMin) {
+        this.budgetMin = budgetMin;
+    }
+
+    public BigDecimal getBudgetMax() {
+        return budgetMax;
+    }
+
+    public void setBudgetMax(BigDecimal budgetMax) {
+        this.budgetMax = budgetMax;
+    }
+
+    public int getPeopleCount() {
+        return peopleCount;
+    }
+
+    public void setPeopleCount(int peopleCount) {
+        this.peopleCount = peopleCount;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public void setNote(String note) {
+        this.note = note;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/UpdateRentalRequestStatusRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/UpdateRentalRequestStatusRequest.java
@@ -1,0 +1,18 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequestStatus;
+
+public class UpdateRentalRequestStatusRequest {
+
+    @NotNull
+    private RentalRequestStatus status;
+
+    public RentalRequestStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(RentalRequestStatus status) {
+        this.status = status;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/UpdateViewingAppointmentRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/UpdateViewingAppointmentRequest.java
@@ -1,0 +1,52 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.UUID;
+
+public class UpdateViewingAppointmentRequest {
+
+    @JsonProperty("sale_id")
+    private UUID saleId;
+
+    @JsonProperty("room_id")
+    private UUID roomId;
+
+    @JsonProperty("bed_id")
+    private UUID bedId;
+
+    @JsonProperty("scheduled_at")
+    private Instant scheduledAt;
+
+    public UUID getSaleId() {
+        return saleId;
+    }
+
+    public void setSaleId(UUID saleId) {
+        this.saleId = saleId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public void setBedId(UUID bedId) {
+        this.bedId = bedId;
+    }
+
+    public Instant getScheduledAt() {
+        return scheduledAt;
+    }
+
+    public void setScheduledAt(Instant scheduledAt) {
+        this.scheduledAt = scheduledAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/ViewingAppointmentResponse.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/ViewingAppointmentResponse.java
@@ -1,0 +1,144 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointment;
+
+public class ViewingAppointmentResponse {
+
+    private UUID id;
+
+    @JsonProperty("rental_request_id")
+    private UUID rentalRequestId;
+
+    @JsonProperty("customer_id")
+    private UUID customerId;
+
+    @JsonProperty("sale_id")
+    private UUID saleId;
+
+    @JsonProperty("room_id")
+    private UUID roomId;
+
+    @JsonProperty("bed_id")
+    private UUID bedId;
+
+    @JsonProperty("scheduled_at")
+    private Instant scheduledAt;
+
+    @JsonProperty("result_note")
+    private String resultNote;
+
+    private String status;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("updated_at")
+    private Instant updatedAt;
+
+    public static ViewingAppointmentResponse from(ViewingAppointment appt) {
+        ViewingAppointmentResponse r = new ViewingAppointmentResponse();
+        r.id = appt.getId();
+        r.rentalRequestId = appt.getRentalRequestId();
+        r.customerId = appt.getCustomerId();
+        r.saleId = appt.getSaleId();
+        r.roomId = appt.getRoomId();
+        r.bedId = appt.getBedId();
+        r.scheduledAt = appt.getScheduledAt();
+        r.resultNote = appt.getResultNote();
+        r.status = appt.getStatus() != null ? appt.getStatus().name().toLowerCase() : null;
+        r.createdAt = appt.getCreatedAt();
+        r.updatedAt = appt.getUpdatedAt();
+        return r;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getRentalRequestId() {
+        return rentalRequestId;
+    }
+
+    public void setRentalRequestId(UUID rentalRequestId) {
+        this.rentalRequestId = rentalRequestId;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+        this.customerId = customerId;
+    }
+
+    public UUID getSaleId() {
+        return saleId;
+    }
+
+    public void setSaleId(UUID saleId) {
+        this.saleId = saleId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public void setBedId(UUID bedId) {
+        this.bedId = bedId;
+    }
+
+    public Instant getScheduledAt() {
+        return scheduledAt;
+    }
+
+    public void setScheduledAt(Instant scheduledAt) {
+        this.scheduledAt = scheduledAt;
+    }
+
+    public String getResultNote() {
+        return resultNote;
+    }
+
+    public void setResultNote(String resultNote) {
+        this.resultNote = resultNote;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RentalRequestEntity.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RentalRequestEntity.java
@@ -1,0 +1,125 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequestStatus;
+
+@Entity
+@Table(name = "rental_requests", schema = "public")
+public class RentalRequestEntity extends BaseEntity {
+
+    @Column(name = "customer_id", nullable = false)
+    private UUID customerId;
+
+    @Column(name = "branch_id")
+    private UUID branchId;
+
+    @Column(name = "room_id")
+    private UUID roomId;
+
+    @Column(name = "bed_id")
+    private UUID bedId;
+
+    @Column(name = "preferred_room_type")
+    private String preferredRoomType;
+
+    @Column(name = "budget_min", precision = 12, scale = 2, nullable = true)
+    private BigDecimal budgetMin;
+
+    @Column(name = "budget_max", precision = 12, scale = 2, nullable = true)
+    private BigDecimal budgetMax;
+
+    @Column(name = "people_count", nullable = false)
+    private int peopleCount = 1;
+
+    @Column(name = "note")
+    private String note;
+
+    @Convert(converter = RentalRequestStatusConverter.class)
+    @Column(name = "status", nullable = false)
+    private RentalRequestStatus status = RentalRequestStatus.REQUESTED;
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+        this.customerId = customerId;
+    }
+
+    public UUID getBranchId() {
+        return branchId;
+    }
+
+    public void setBranchId(UUID branchId) {
+        this.branchId = branchId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public void setBedId(UUID bedId) {
+        this.bedId = bedId;
+    }
+
+    public String getPreferredRoomType() {
+        return preferredRoomType;
+    }
+
+    public void setPreferredRoomType(String preferredRoomType) {
+        this.preferredRoomType = preferredRoomType;
+    }
+
+    public BigDecimal getBudgetMin() {
+        return budgetMin;
+    }
+
+    public void setBudgetMin(BigDecimal budgetMin) {
+        this.budgetMin = budgetMin;
+    }
+
+    public BigDecimal getBudgetMax() {
+        return budgetMax;
+    }
+
+    public void setBudgetMax(BigDecimal budgetMax) {
+        this.budgetMax = budgetMax;
+    }
+
+    public int getPeopleCount() {
+        return peopleCount;
+    }
+
+    public void setPeopleCount(int peopleCount) {
+        this.peopleCount = peopleCount;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public void setNote(String note) {
+        this.note = note;
+    }
+
+    public RentalRequestStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(RentalRequestStatus status) {
+        this.status = status;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RentalRequestJpaRepository.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RentalRequestJpaRepository.java
@@ -1,0 +1,10 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface RentalRequestJpaRepository extends JpaRepository<RentalRequestEntity, UUID> {
+
+    List<RentalRequestEntity> findByCustomerId(UUID customerId);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RentalRequestMapper.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RentalRequestMapper.java
@@ -1,0 +1,43 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+
+@Component
+class RentalRequestMapper {
+
+    RentalRequest toDomain(RentalRequestEntity e) {
+        return new RentalRequest(
+                e.getId(),
+                e.getCustomerId(),
+                e.getBranchId(),
+                e.getRoomId(),
+                e.getBedId(),
+                e.getPreferredRoomType(),
+                e.getBudgetMin(),
+                e.getBudgetMax(),
+                e.getPeopleCount(),
+                e.getNote(),
+                e.getStatus(),
+                e.getCreatedAt(),
+                e.getUpdatedAt());
+    }
+
+    RentalRequestEntity toEntity(RentalRequest r) {
+        RentalRequestEntity e = new RentalRequestEntity();
+        if (r.getId() != null) {
+            e.setId(r.getId());
+        }
+        e.setCustomerId(r.getCustomerId());
+        e.setBranchId(r.getBranchId());
+        e.setRoomId(r.getRoomId());
+        e.setBedId(r.getBedId());
+        e.setPreferredRoomType(r.getPreferredRoomType());
+        e.setBudgetMin(r.getBudgetMin());
+        e.setBudgetMax(r.getBudgetMax());
+        e.setPeopleCount(r.getPeopleCount());
+        e.setNote(r.getNote());
+        e.setStatus(r.getStatus());
+        return e;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RentalRequestPersistenceAdapter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RentalRequestPersistenceAdapter.java
@@ -1,0 +1,42 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.application.port.out.LoadRentalRequestPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveRentalRequestPort;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+
+@Component
+class RentalRequestPersistenceAdapter implements LoadRentalRequestPort, SaveRentalRequestPort {
+
+    private final RentalRequestJpaRepository jpaRepository;
+    private final RentalRequestMapper mapper;
+
+    RentalRequestPersistenceAdapter(
+            RentalRequestJpaRepository jpaRepository, RentalRequestMapper mapper) {
+        this.jpaRepository = jpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Optional<RentalRequest> loadById(UUID id) {
+        return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public List<RentalRequest> loadByCustomerId(UUID customerId) {
+        return jpaRepository.findByCustomerId(customerId).stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public List<RentalRequest> loadAll() {
+        return jpaRepository.findAll().stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public RentalRequest save(RentalRequest request) {
+        return mapper.toDomain(jpaRepository.save(mapper.toEntity(request)));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RentalRequestStatusConverter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/RentalRequestStatusConverter.java
@@ -1,0 +1,20 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequestStatus;
+
+@Converter(autoApply = true)
+public class RentalRequestStatusConverter implements AttributeConverter<RentalRequestStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(RentalRequestStatus status) {
+        return status == null ? null : status.name().toLowerCase();
+    }
+
+    @Override
+    public RentalRequestStatus convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        return RentalRequestStatus.valueOf(dbData.toUpperCase());
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ViewingAppointmentEntity.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ViewingAppointmentEntity.java
@@ -1,0 +1,103 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointmentStatus;
+
+@Entity
+@Table(name = "viewing_appointments", schema = "public")
+public class ViewingAppointmentEntity extends BaseEntity {
+
+    @Column(name = "rental_request_id", nullable = false)
+    private UUID rentalRequestId;
+
+    @Column(name = "customer_id", nullable = false)
+    private UUID customerId;
+
+    @Column(name = "sale_id")
+    private UUID saleId;
+
+    @Column(name = "room_id")
+    private UUID roomId;
+
+    @Column(name = "bed_id")
+    private UUID bedId;
+
+    @Column(name = "scheduled_at", nullable = false)
+    private Instant scheduledAt;
+
+    @Column(name = "result_note")
+    private String resultNote;
+
+    @Convert(converter = ViewingAppointmentStatusConverter.class)
+    @Column(name = "status", nullable = false)
+    private ViewingAppointmentStatus status = ViewingAppointmentStatus.SCHEDULED;
+
+    public UUID getRentalRequestId() {
+        return rentalRequestId;
+    }
+
+    public void setRentalRequestId(UUID rentalRequestId) {
+        this.rentalRequestId = rentalRequestId;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+        this.customerId = customerId;
+    }
+
+    public UUID getSaleId() {
+        return saleId;
+    }
+
+    public void setSaleId(UUID saleId) {
+        this.saleId = saleId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public void setBedId(UUID bedId) {
+        this.bedId = bedId;
+    }
+
+    public Instant getScheduledAt() {
+        return scheduledAt;
+    }
+
+    public void setScheduledAt(Instant scheduledAt) {
+        this.scheduledAt = scheduledAt;
+    }
+
+    public String getResultNote() {
+        return resultNote;
+    }
+
+    public void setResultNote(String resultNote) {
+        this.resultNote = resultNote;
+    }
+
+    public ViewingAppointmentStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ViewingAppointmentStatus status) {
+        this.status = status;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ViewingAppointmentJpaRepository.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ViewingAppointmentJpaRepository.java
@@ -1,0 +1,6 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface ViewingAppointmentJpaRepository extends JpaRepository<ViewingAppointmentEntity, UUID> {}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ViewingAppointmentMapper.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ViewingAppointmentMapper.java
@@ -1,0 +1,39 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointment;
+
+@Component
+class ViewingAppointmentMapper {
+
+    ViewingAppointment toDomain(ViewingAppointmentEntity e) {
+        return new ViewingAppointment(
+                e.getId(),
+                e.getRentalRequestId(),
+                e.getCustomerId(),
+                e.getSaleId(),
+                e.getRoomId(),
+                e.getBedId(),
+                e.getScheduledAt(),
+                e.getResultNote(),
+                e.getStatus(),
+                e.getCreatedAt(),
+                e.getUpdatedAt());
+    }
+
+    ViewingAppointmentEntity toEntity(ViewingAppointment a) {
+        ViewingAppointmentEntity e = new ViewingAppointmentEntity();
+        if (a.getId() != null) {
+            e.setId(a.getId());
+        }
+        e.setRentalRequestId(a.getRentalRequestId());
+        e.setCustomerId(a.getCustomerId());
+        e.setSaleId(a.getSaleId());
+        e.setRoomId(a.getRoomId());
+        e.setBedId(a.getBedId());
+        e.setScheduledAt(a.getScheduledAt());
+        e.setResultNote(a.getResultNote());
+        e.setStatus(a.getStatus());
+        return e;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ViewingAppointmentPersistenceAdapter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ViewingAppointmentPersistenceAdapter.java
@@ -1,0 +1,37 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.application.port.out.LoadViewingAppointmentPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveViewingAppointmentPort;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointment;
+
+@Component
+class ViewingAppointmentPersistenceAdapter implements LoadViewingAppointmentPort, SaveViewingAppointmentPort {
+
+    private final ViewingAppointmentJpaRepository jpaRepository;
+    private final ViewingAppointmentMapper mapper;
+
+    ViewingAppointmentPersistenceAdapter(
+            ViewingAppointmentJpaRepository jpaRepository, ViewingAppointmentMapper mapper) {
+        this.jpaRepository = jpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Optional<ViewingAppointment> loadById(UUID id) {
+        return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public List<ViewingAppointment> loadAll() {
+        return jpaRepository.findAll().stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public ViewingAppointment save(ViewingAppointment appointment) {
+        return mapper.toDomain(jpaRepository.save(mapper.toEntity(appointment)));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ViewingAppointmentStatusConverter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/ViewingAppointmentStatusConverter.java
@@ -1,0 +1,20 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointmentStatus;
+
+@Converter(autoApply = true)
+public class ViewingAppointmentStatusConverter implements AttributeConverter<ViewingAppointmentStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ViewingAppointmentStatus status) {
+        return status == null ? null : status.name().toLowerCase();
+    }
+
+    @Override
+    public ViewingAppointmentStatus convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        return ViewingAppointmentStatus.valueOf(dbData.toUpperCase());
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateRentalRequestUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateRentalRequestUseCase.java
@@ -1,0 +1,21 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+
+public interface CreateRentalRequestUseCase {
+
+    RentalRequest createRentalRequest(CreateRentalRequestCommand command);
+
+    record CreateRentalRequestCommand(
+            UUID customerId,
+            UUID branchId,
+            UUID roomId,
+            UUID bedId,
+            String preferredRoomType,
+            BigDecimal budgetMin,
+            BigDecimal budgetMax,
+            int peopleCount,
+            String note) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateViewingAppointmentUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateViewingAppointmentUseCase.java
@@ -1,0 +1,18 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointment;
+
+public interface CreateViewingAppointmentUseCase {
+
+    ViewingAppointment createViewingAppointment(CreateViewingAppointmentCommand command);
+
+    record CreateViewingAppointmentCommand(
+            UUID rentalRequestId,
+            UUID customerId,
+            UUID saleId,
+            UUID roomId,
+            UUID bedId,
+            Instant scheduledAt) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetRentalRequestUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetRentalRequestUseCase.java
@@ -1,0 +1,15 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.List;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.adapter.in.security.UserPrincipal;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+
+public interface GetRentalRequestUseCase {
+
+    RentalRequest getRentalRequest(UUID id, UserPrincipal caller);
+
+    List<RentalRequest> getMyRentalRequests(UUID customerId);
+
+    List<RentalRequest> getAllRentalRequests();
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetViewingAppointmentUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetViewingAppointmentUseCase.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.List;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointment;
+
+public interface GetViewingAppointmentUseCase {
+
+    ViewingAppointment getViewingAppointment(UUID id);
+
+    List<ViewingAppointment> getAllViewingAppointments();
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/UpdateRentalRequestStatusUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/UpdateRentalRequestStatusUseCase.java
@@ -1,0 +1,10 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequestStatus;
+
+public interface UpdateRentalRequestStatusUseCase {
+
+    RentalRequest updateStatus(UUID id, RentalRequestStatus newStatus);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/UpdateViewingAppointmentUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/UpdateViewingAppointmentUseCase.java
@@ -1,0 +1,19 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointment;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointmentStatus;
+
+public interface UpdateViewingAppointmentUseCase {
+
+    ViewingAppointment cancelAppointment(UUID id);
+
+    ViewingAppointment recordOutcome(UUID id, RecordOutcomeCommand command);
+
+    ViewingAppointment updateAppointment(UUID id, UpdateAppointmentCommand command);
+
+    record RecordOutcomeCommand(String resultNote, ViewingAppointmentStatus status) {}
+
+    record UpdateAppointmentCommand(UUID saleId, UUID roomId, UUID bedId, Instant scheduledAt) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadRentalRequestPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadRentalRequestPort.java
@@ -1,0 +1,15 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+
+public interface LoadRentalRequestPort {
+
+    Optional<RentalRequest> loadById(UUID id);
+
+    List<RentalRequest> loadByCustomerId(UUID customerId);
+
+    List<RentalRequest> loadAll();
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadViewingAppointmentPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadViewingAppointmentPort.java
@@ -1,0 +1,13 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointment;
+
+public interface LoadViewingAppointmentPort {
+
+    Optional<ViewingAppointment> loadById(UUID id);
+
+    List<ViewingAppointment> loadAll();
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveRentalRequestPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveRentalRequestPort.java
@@ -1,0 +1,8 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+
+public interface SaveRentalRequestPort {
+
+    RentalRequest save(RentalRequest request);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveViewingAppointmentPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveViewingAppointmentPort.java
@@ -1,0 +1,8 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointment;
+
+public interface SaveViewingAppointmentPort {
+
+    ViewingAppointment save(ViewingAppointment appointment);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/RentalRequestService.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/RentalRequestService.java
@@ -1,0 +1,82 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import vn.edu.hcmus.homestay.adapter.in.security.UserPrincipal;
+import vn.edu.hcmus.homestay.application.port.in.CreateRentalRequestUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetRentalRequestUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateRentalRequestStatusUseCase;
+import vn.edu.hcmus.homestay.application.port.out.LoadRentalRequestPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveRentalRequestPort;
+import vn.edu.hcmus.homestay.common.exception.ForbiddenException;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequestStatus;
+import vn.edu.hcmus.homestay.domain.model.user.AppRole;
+
+@Service
+public class RentalRequestService
+        implements CreateRentalRequestUseCase, GetRentalRequestUseCase, UpdateRentalRequestStatusUseCase {
+
+    private final LoadRentalRequestPort loadRentalRequestPort;
+    private final SaveRentalRequestPort saveRentalRequestPort;
+
+    public RentalRequestService(
+            LoadRentalRequestPort loadRentalRequestPort,
+            SaveRentalRequestPort saveRentalRequestPort) {
+        this.loadRentalRequestPort = loadRentalRequestPort;
+        this.saveRentalRequestPort = saveRentalRequestPort;
+    }
+
+    @Override
+    public RentalRequest createRentalRequest(CreateRentalRequestCommand command) {
+        RentalRequest request = new RentalRequest(
+                null,
+                command.customerId(),
+                command.branchId(),
+                command.roomId(),
+                command.bedId(),
+                command.preferredRoomType(),
+                command.budgetMin(),
+                command.budgetMax(),
+                command.peopleCount(),
+                command.note(),
+                RentalRequestStatus.REQUESTED,
+                null,
+                null);
+        return saveRentalRequestPort.save(request);
+    }
+
+    @Override
+    public RentalRequest getRentalRequest(UUID id, UserPrincipal caller) {
+        RentalRequest req = loadRentalRequestPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Rental request not found"));
+
+        boolean isOwner = req.getCustomerId().equals(caller.getId());
+        boolean isStaff = caller.getRole() != AppRole.CUSTOMER;
+        if (!isOwner && !isStaff) {
+            throw new ForbiddenException("Access denied");
+        }
+        return req;
+    }
+
+    @Override
+    public List<RentalRequest> getMyRentalRequests(UUID customerId) {
+        return loadRentalRequestPort.loadByCustomerId(customerId);
+    }
+
+    @Override
+    public List<RentalRequest> getAllRentalRequests() {
+        return loadRentalRequestPort.loadAll();
+    }
+
+    @Override
+    public RentalRequest updateStatus(UUID id, RentalRequestStatus newStatus) {
+        RentalRequest existing = loadRentalRequestPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Rental request not found"));
+        return saveRentalRequestPort.save(existing.withStatus(newStatus));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/ViewingAppointmentService.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/ViewingAppointmentService.java
@@ -1,0 +1,90 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import vn.edu.hcmus.homestay.application.port.in.CreateViewingAppointmentUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetViewingAppointmentUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateViewingAppointmentUseCase;
+import vn.edu.hcmus.homestay.application.port.out.LoadRentalRequestPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadViewingAppointmentPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveViewingAppointmentPort;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointment;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointmentStatus;
+
+@Service
+public class ViewingAppointmentService
+        implements CreateViewingAppointmentUseCase, GetViewingAppointmentUseCase, UpdateViewingAppointmentUseCase {
+
+    private final LoadViewingAppointmentPort loadViewingAppointmentPort;
+    private final SaveViewingAppointmentPort saveViewingAppointmentPort;
+    private final LoadRentalRequestPort loadRentalRequestPort;
+
+    public ViewingAppointmentService(
+            LoadViewingAppointmentPort loadViewingAppointmentPort,
+            SaveViewingAppointmentPort saveViewingAppointmentPort,
+            LoadRentalRequestPort loadRentalRequestPort) {
+        this.loadViewingAppointmentPort = loadViewingAppointmentPort;
+        this.saveViewingAppointmentPort = saveViewingAppointmentPort;
+        this.loadRentalRequestPort = loadRentalRequestPort;
+    }
+
+    @Override
+    public ViewingAppointment createViewingAppointment(CreateViewingAppointmentCommand command) {
+        loadRentalRequestPort
+                .loadById(command.rentalRequestId())
+                .orElseThrow(() -> new NotFoundException("Rental request not found"));
+
+        ViewingAppointment appointment = new ViewingAppointment(
+                null,
+                command.rentalRequestId(),
+                command.customerId(),
+                command.saleId(),
+                command.roomId(),
+                command.bedId(),
+                command.scheduledAt(),
+                null,
+                ViewingAppointmentStatus.SCHEDULED,
+                null,
+                null);
+        return saveViewingAppointmentPort.save(appointment);
+    }
+
+    @Override
+    public ViewingAppointment getViewingAppointment(UUID id) {
+        return loadViewingAppointmentPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Viewing appointment not found"));
+    }
+
+    @Override
+    public List<ViewingAppointment> getAllViewingAppointments() {
+        return loadViewingAppointmentPort.loadAll();
+    }
+
+    @Override
+    public ViewingAppointment cancelAppointment(UUID id) {
+        ViewingAppointment existing = loadViewingAppointmentPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Viewing appointment not found"));
+        return saveViewingAppointmentPort.save(existing.withStatus(ViewingAppointmentStatus.CANCELLED));
+    }
+
+    @Override
+    public ViewingAppointment recordOutcome(UUID id, RecordOutcomeCommand command) {
+        ViewingAppointment existing = loadViewingAppointmentPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Viewing appointment not found"));
+        return saveViewingAppointmentPort.save(existing.withOutcome(command.resultNote(), command.status()));
+    }
+
+    @Override
+    public ViewingAppointment updateAppointment(UUID id, UpdateAppointmentCommand command) {
+        ViewingAppointment existing = loadViewingAppointmentPort
+                .loadById(id)
+                .orElseThrow(() -> new NotFoundException("Viewing appointment not found"));
+        return saveViewingAppointmentPort.save(
+                existing.withUpdates(command.saleId(), command.roomId(), command.bedId(), command.scheduledAt()));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/rental/RentalRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/rental/RentalRequest.java
@@ -1,0 +1,112 @@
+package vn.edu.hcmus.homestay.domain.model.rental;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/** Pure domain entity — no JPA annotations, no Spring dependencies. */
+public class RentalRequest {
+
+    private final UUID id;
+    private final UUID customerId;
+    private final UUID branchId;
+    private final UUID roomId;
+    private final UUID bedId;
+    private final String preferredRoomType;
+    private final BigDecimal budgetMin;
+    private final BigDecimal budgetMax;
+    private final int peopleCount;
+    private final String note;
+    private final RentalRequestStatus status;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public RentalRequest(
+            UUID id,
+            UUID customerId,
+            UUID branchId,
+            UUID roomId,
+            UUID bedId,
+            String preferredRoomType,
+            BigDecimal budgetMin,
+            BigDecimal budgetMax,
+            int peopleCount,
+            String note,
+            RentalRequestStatus status,
+            Instant createdAt,
+            Instant updatedAt) {
+        this.id = id;
+        this.customerId = customerId;
+        this.branchId = branchId;
+        this.roomId = roomId;
+        this.bedId = bedId;
+        this.preferredRoomType = preferredRoomType;
+        this.budgetMin = budgetMin;
+        this.budgetMax = budgetMax;
+        this.peopleCount = peopleCount;
+        this.note = note;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public UUID getBranchId() {
+        return branchId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public String getPreferredRoomType() {
+        return preferredRoomType;
+    }
+
+    public BigDecimal getBudgetMin() {
+        return budgetMin;
+    }
+
+    public BigDecimal getBudgetMax() {
+        return budgetMax;
+    }
+
+    public int getPeopleCount() {
+        return peopleCount;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public RentalRequestStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    /** Returns a copy of this request with a new status. */
+    public RentalRequest withStatus(RentalRequestStatus newStatus) {
+        return new RentalRequest(
+                id, customerId, branchId, roomId, bedId,
+                preferredRoomType, budgetMin, budgetMax, peopleCount, note,
+                newStatus, createdAt, updatedAt);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/rental/RentalRequestStatus.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/rental/RentalRequestStatus.java
@@ -1,0 +1,27 @@
+package vn.edu.hcmus.homestay.domain.model.rental;
+
+import java.util.Map;
+import java.util.Set;
+
+public enum RentalRequestStatus {
+    REQUESTED,
+    REVIEWING,
+    VIEWING_SCHEDULED,
+    ACCEPTED,
+    REJECTED,
+    CANCELLED,
+    DEPOSIT_PENDING,
+    COMPLETED;
+
+    /** Documents valid transitions — not yet enforced, used as refactor baseline. */
+    public static final Map<RentalRequestStatus, Set<RentalRequestStatus>> VALID_TRANSITIONS =
+            Map.of(
+                    REQUESTED, Set.of(REVIEWING, CANCELLED),
+                    REVIEWING, Set.of(VIEWING_SCHEDULED, ACCEPTED, REJECTED, CANCELLED),
+                    VIEWING_SCHEDULED, Set.of(ACCEPTED, REJECTED, CANCELLED),
+                    ACCEPTED, Set.of(DEPOSIT_PENDING, CANCELLED),
+                    DEPOSIT_PENDING, Set.of(COMPLETED, CANCELLED),
+                    REJECTED, Set.of(),
+                    CANCELLED, Set.of(),
+                    COMPLETED, Set.of());
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/viewing/ViewingAppointment.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/viewing/ViewingAppointment.java
@@ -1,0 +1,114 @@
+package vn.edu.hcmus.homestay.domain.model.viewing;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** Pure domain entity — no JPA annotations, no Spring dependencies. */
+public class ViewingAppointment {
+
+    private final UUID id;
+    private final UUID rentalRequestId;
+    private final UUID customerId;
+    private final UUID saleId;
+    private final UUID roomId;
+    private final UUID bedId;
+    private final Instant scheduledAt;
+    private final String resultNote;
+    private final ViewingAppointmentStatus status;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public ViewingAppointment(
+            UUID id,
+            UUID rentalRequestId,
+            UUID customerId,
+            UUID saleId,
+            UUID roomId,
+            UUID bedId,
+            Instant scheduledAt,
+            String resultNote,
+            ViewingAppointmentStatus status,
+            Instant createdAt,
+            Instant updatedAt) {
+        this.id = id;
+        this.rentalRequestId = rentalRequestId;
+        this.customerId = customerId;
+        this.saleId = saleId;
+        this.roomId = roomId;
+        this.bedId = bedId;
+        this.scheduledAt = scheduledAt;
+        this.resultNote = resultNote;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getRentalRequestId() {
+        return rentalRequestId;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public UUID getSaleId() {
+        return saleId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public Instant getScheduledAt() {
+        return scheduledAt;
+    }
+
+    public String getResultNote() {
+        return resultNote;
+    }
+
+    public ViewingAppointmentStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    /** Returns a copy with a new status. */
+    public ViewingAppointment withStatus(ViewingAppointmentStatus newStatus) {
+        return new ViewingAppointment(
+                id, rentalRequestId, customerId, saleId, roomId, bedId,
+                scheduledAt, resultNote, newStatus, createdAt, updatedAt);
+    }
+
+    /** Returns a copy with updated resultNote and status (record outcome). */
+    public ViewingAppointment withOutcome(String newResultNote, ViewingAppointmentStatus newStatus) {
+        return new ViewingAppointment(
+                id, rentalRequestId, customerId, saleId, roomId, bedId,
+                scheduledAt, newResultNote, newStatus, createdAt, updatedAt);
+    }
+
+    /** Returns a copy with updated scheduling fields. */
+    public ViewingAppointment withUpdates(UUID newSaleId, UUID newRoomId, UUID newBedId, Instant newScheduledAt) {
+        return new ViewingAppointment(
+                id, rentalRequestId, customerId,
+                newSaleId != null ? newSaleId : saleId,
+                newRoomId != null ? newRoomId : roomId,
+                newBedId != null ? newBedId : bedId,
+                newScheduledAt != null ? newScheduledAt : scheduledAt,
+                resultNote, status, createdAt, updatedAt);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/viewing/ViewingAppointmentStatus.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/viewing/ViewingAppointmentStatus.java
@@ -1,0 +1,8 @@
+package vn.edu.hcmus.homestay.domain.model.viewing;
+
+public enum ViewingAppointmentStatus {
+    SCHEDULED,
+    COMPLETED,
+    CANCELLED,
+    NO_SHOW
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/RentalRequestControllerTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/RentalRequestControllerTest.java
@@ -1,0 +1,209 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import vn.edu.hcmus.homestay.adapter.in.security.UserPrincipal;
+import vn.edu.hcmus.homestay.adapter.out.security.JwtTokenProvider;
+import vn.edu.hcmus.homestay.application.port.in.CreateRentalRequestUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetRentalRequestUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateRentalRequestStatusUseCase;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.config.SecurityConfig;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequestStatus;
+import vn.edu.hcmus.homestay.domain.model.user.AppRole;
+
+@WebMvcTest(RentalRequestController.class)
+@Import(SecurityConfig.class)
+class RentalRequestControllerTest {
+
+    private static final String SECRET = "change-me-to-a-real-secret-at-least-32-chars";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CreateRentalRequestUseCase createRentalRequestUseCase;
+
+    @MockitoBean
+    private GetRentalRequestUseCase getRentalRequestUseCase;
+
+    @MockitoBean
+    private UpdateRentalRequestStatusUseCase updateRentalRequestStatusUseCase;
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void getMyRequests_authenticated_200() throws Exception {
+        UUID customerId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(customerId, "customer@example.com", AppRole.CUSTOMER);
+        when(getRentalRequestUseCase.getMyRentalRequests(customerId)).thenReturn(List.of());
+
+        mockMvc.perform(
+                        get("/api/rental-requests/my-requests")
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void getAllRequests_asCustomer_403() throws Exception {
+        UUID customerId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(customerId, "customer@example.com", AppRole.CUSTOMER);
+
+        mockMvc.perform(
+                        get("/api/rental-requests")
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getAllRequests_asStaff_200() throws Exception {
+        UUID staffId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(staffId, "sale@example.com", AppRole.SALE);
+        when(getRentalRequestUseCase.getAllRentalRequests()).thenReturn(List.of());
+
+        mockMvc.perform(
+                        get("/api/rental-requests")
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void createRentalRequest_unauthenticated_401() throws Exception {
+        mockMvc.perform(
+                        post("/api/rental-requests")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"people_count\":1}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void updateStatus_unauthenticated_401() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(
+                        patch("/api/rental-requests/{id}/status", id)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"status\":\"REVIEWING\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getRentalRequest_authenticated_200() throws Exception {
+        UUID customerId = UUID.randomUUID();
+        UUID requestId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(customerId, "customer@example.com", AppRole.CUSTOMER);
+        when(getRentalRequestUseCase.getRentalRequest(eq(requestId), any())).thenReturn(
+                rentalRequest(requestId, customerId));
+
+        mockMvc.perform(
+                        get("/api/rental-requests/{id}", requestId)
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(requestId.toString()));
+    }
+
+    @Test
+    void getRentalRequest_notFound_404() throws Exception {
+        UUID requestId = UUID.randomUUID();
+        UUID staffId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(staffId, "sale@example.com", AppRole.SALE);
+        when(getRentalRequestUseCase.getRentalRequest(eq(requestId), any()))
+                .thenThrow(new NotFoundException("Rental request not found"));
+
+        mockMvc.perform(
+                        get("/api/rental-requests/{id}", requestId)
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void createRentalRequest_authenticated_201() throws Exception {
+        UUID customerId = UUID.randomUUID();
+        UUID requestId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(customerId, "customer@example.com", AppRole.CUSTOMER);
+        when(createRentalRequestUseCase.createRentalRequest(any())).thenReturn(
+                rentalRequest(requestId, customerId));
+
+        mockMvc.perform(
+                        post("/api/rental-requests")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"people_count\":2}")
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void updateStatus_asStaff_200() throws Exception {
+        UUID requestId = UUID.randomUUID();
+        UUID staffId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(staffId, "sale@example.com", AppRole.SALE);
+        when(updateRentalRequestStatusUseCase.updateStatus(eq(requestId), any())).thenReturn(
+                rentalRequest(requestId, UUID.randomUUID()));
+
+        mockMvc.perform(
+                        patch("/api/rental-requests/{id}/status", requestId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"status\":\"REVIEWING\"}")
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private RentalRequest rentalRequest(UUID id, UUID customerId) {
+        return new RentalRequest(
+                id, customerId, null, null, null, null, null, null,
+                1, null, RentalRequestStatus.REQUESTED, Instant.now(), Instant.now());
+    }
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Primary
+        @Bean
+        public JwtTokenProvider jwtTokenProvider() {
+            return new JwtTokenProvider(SECRET);
+        }
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/ViewingAppointmentControllerTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/ViewingAppointmentControllerTest.java
@@ -1,0 +1,199 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import vn.edu.hcmus.homestay.adapter.in.security.UserPrincipal;
+import vn.edu.hcmus.homestay.adapter.out.security.JwtTokenProvider;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import vn.edu.hcmus.homestay.application.port.in.CreateViewingAppointmentUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetViewingAppointmentUseCase;
+import vn.edu.hcmus.homestay.application.port.in.UpdateViewingAppointmentUseCase;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.config.SecurityConfig;
+import vn.edu.hcmus.homestay.domain.model.user.AppRole;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointment;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointmentStatus;
+
+@WebMvcTest(ViewingAppointmentController.class)
+@Import(SecurityConfig.class)
+class ViewingAppointmentControllerTest {
+
+    private static final String SECRET = "change-me-to-a-real-secret-at-least-32-chars";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CreateViewingAppointmentUseCase createViewingAppointmentUseCase;
+
+    @MockitoBean
+    private GetViewingAppointmentUseCase getViewingAppointmentUseCase;
+
+    @MockitoBean
+    private UpdateViewingAppointmentUseCase updateViewingAppointmentUseCase;
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void getAllAppointments_unauthenticated_401() throws Exception {
+        mockMvc.perform(get("/api/viewing-appointments"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getAllAppointments_asCustomer_403() throws Exception {
+        UUID customerId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(customerId, "customer@example.com", AppRole.CUSTOMER);
+
+        mockMvc.perform(
+                        get("/api/viewing-appointments")
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getAllAppointments_asStaff_200() throws Exception {
+        UUID staffId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(staffId, "sale@example.com", AppRole.SALE);
+        when(getViewingAppointmentUseCase.getAllViewingAppointments()).thenReturn(List.of());
+
+        mockMvc.perform(
+                        get("/api/viewing-appointments")
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void createAppointment_unauthenticated_401() throws Exception {
+        mockMvc.perform(
+                        post("/api/viewing-appointments")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                        {
+                                          "rental_request_id":"00000000-0000-0000-0000-000000000001",
+                                          "customer_id":"00000000-0000-0000-0000-000000000002",
+                                          "scheduled_at":"2026-07-01T10:00:00Z"
+                                        }
+                                        """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getViewingAppointment_asStaff_200() throws Exception {
+        UUID staffId = UUID.randomUUID();
+        UUID appointmentId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(staffId, "sale@example.com", AppRole.SALE);
+        when(getViewingAppointmentUseCase.getViewingAppointment(appointmentId)).thenReturn(
+                appointment(appointmentId));
+
+        mockMvc.perform(
+                        get("/api/viewing-appointments/{id}", appointmentId)
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(appointmentId.toString()));
+    }
+
+    @Test
+    void getViewingAppointment_notFound_404() throws Exception {
+        UUID staffId = UUID.randomUUID();
+        UUID appointmentId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(staffId, "sale@example.com", AppRole.SALE);
+        when(getViewingAppointmentUseCase.getViewingAppointment(appointmentId))
+                .thenThrow(new NotFoundException("Viewing appointment not found"));
+
+        mockMvc.perform(
+                        get("/api/viewing-appointments/{id}", appointmentId)
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void cancelAppointment_asStaff_200() throws Exception {
+        UUID staffId = UUID.randomUUID();
+        UUID appointmentId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(staffId, "sale@example.com", AppRole.SALE);
+        ViewingAppointment cancelled = new ViewingAppointment(
+                appointmentId, UUID.randomUUID(), UUID.randomUUID(), null, null, null,
+                Instant.now(), null, ViewingAppointmentStatus.CANCELLED, Instant.now(), Instant.now());
+        when(updateViewingAppointmentUseCase.cancelAppointment(appointmentId)).thenReturn(cancelled);
+
+        mockMvc.perform(
+                        patch("/api/viewing-appointments/{id}/cancel", appointmentId)
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void recordOutcome_asStaff_200() throws Exception {
+        UUID staffId = UUID.randomUUID();
+        UUID appointmentId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(staffId, "sale@example.com", AppRole.SALE);
+        ViewingAppointment completed = new ViewingAppointment(
+                appointmentId, UUID.randomUUID(), UUID.randomUUID(), null, null, null,
+                Instant.now(), "Looks good", ViewingAppointmentStatus.COMPLETED, Instant.now(), Instant.now());
+        when(updateViewingAppointmentUseCase.recordOutcome(eq(appointmentId), any())).thenReturn(completed);
+
+        mockMvc.perform(
+                        patch("/api/viewing-appointments/{id}/outcome", appointmentId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"result_note\":\"Looks good\",\"status\":\"COMPLETED\"}")
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                        new UsernamePasswordAuthenticationToken(
+                                                principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private ViewingAppointment appointment(UUID id) {
+        return new ViewingAppointment(
+                id, UUID.randomUUID(), UUID.randomUUID(), null, null, null,
+                Instant.now(), null, ViewingAppointmentStatus.SCHEDULED, Instant.now(), Instant.now());
+    }
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Primary
+        @Bean
+        public JwtTokenProvider jwtTokenProvider() {
+            return new JwtTokenProvider(SECRET);
+        }
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/RentalRequestServiceTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/RentalRequestServiceTest.java
@@ -1,0 +1,171 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import vn.edu.hcmus.homestay.adapter.in.security.UserPrincipal;
+import vn.edu.hcmus.homestay.application.port.in.CreateRentalRequestUseCase.CreateRentalRequestCommand;
+import vn.edu.hcmus.homestay.application.port.out.LoadRentalRequestPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveRentalRequestPort;
+import vn.edu.hcmus.homestay.common.exception.ForbiddenException;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequestStatus;
+import vn.edu.hcmus.homestay.domain.model.user.AppRole;
+
+@ExtendWith(MockitoExtension.class)
+class RentalRequestServiceTest {
+
+    @Mock
+    private LoadRentalRequestPort loadRentalRequestPort;
+
+    @Mock
+    private SaveRentalRequestPort saveRentalRequestPort;
+
+    private RentalRequestService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RentalRequestService(loadRentalRequestPort, saveRentalRequestPort);
+    }
+
+    // ── createRentalRequest ───────────────────────────────────────────────────
+
+    @Test
+    void createRentalRequest_saves_withRequestedStatus() {
+        UUID customerId = UUID.randomUUID();
+        RentalRequest saved = rentalRequest(UUID.randomUUID(), customerId, RentalRequestStatus.REQUESTED);
+        when(saveRentalRequestPort.save(any())).thenReturn(saved);
+
+        RentalRequest result = service.createRentalRequest(
+                new CreateRentalRequestCommand(customerId, null, null, null, null, null, null, 1, null));
+
+        assertThat(result.getStatus()).isEqualTo(RentalRequestStatus.REQUESTED);
+        verify(saveRentalRequestPort).save(any(RentalRequest.class));
+    }
+
+    // ── getRentalRequest ──────────────────────────────────────────────────────
+
+    @Test
+    void getRentalRequest_owner_allowed() {
+        UUID customerId = UUID.randomUUID();
+        UUID requestId = UUID.randomUUID();
+        RentalRequest req = rentalRequest(requestId, customerId, RentalRequestStatus.REQUESTED);
+        when(loadRentalRequestPort.loadById(requestId)).thenReturn(Optional.of(req));
+        UserPrincipal caller = new UserPrincipal(customerId, "customer@example.com", AppRole.CUSTOMER);
+
+        RentalRequest result = service.getRentalRequest(requestId, caller);
+
+        assertThat(result).isEqualTo(req);
+    }
+
+    @Test
+    void getRentalRequest_staff_allowed() {
+        UUID customerId = UUID.randomUUID();
+        UUID staffId = UUID.randomUUID();
+        UUID requestId = UUID.randomUUID();
+        RentalRequest req = rentalRequest(requestId, customerId, RentalRequestStatus.REQUESTED);
+        when(loadRentalRequestPort.loadById(requestId)).thenReturn(Optional.of(req));
+        UserPrincipal caller = new UserPrincipal(staffId, "sale@example.com", AppRole.SALE);
+
+        RentalRequest result = service.getRentalRequest(requestId, caller);
+
+        assertThat(result).isEqualTo(req);
+    }
+
+    @Test
+    void getRentalRequest_otherCustomer_throwsForbidden() {
+        UUID ownerId = UUID.randomUUID();
+        UUID otherId = UUID.randomUUID();
+        UUID requestId = UUID.randomUUID();
+        RentalRequest req = rentalRequest(requestId, ownerId, RentalRequestStatus.REQUESTED);
+        when(loadRentalRequestPort.loadById(requestId)).thenReturn(Optional.of(req));
+        UserPrincipal caller = new UserPrincipal(otherId, "other@example.com", AppRole.CUSTOMER);
+
+        assertThatThrownBy(() -> service.getRentalRequest(requestId, caller))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void getRentalRequest_notFound_throwsNotFoundException() {
+        UUID requestId = UUID.randomUUID();
+        when(loadRentalRequestPort.loadById(requestId)).thenReturn(Optional.empty());
+        UserPrincipal caller = new UserPrincipal(UUID.randomUUID(), "sale@example.com", AppRole.SALE);
+
+        assertThatThrownBy(() -> service.getRentalRequest(requestId, caller))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── getMyRentalRequests ───────────────────────────────────────────────────
+
+    @Test
+    void getMyRentalRequests_returnsOwnRequests() {
+        UUID customerId = UUID.randomUUID();
+        RentalRequest r1 = rentalRequest(UUID.randomUUID(), customerId, RentalRequestStatus.REQUESTED);
+        RentalRequest r2 = rentalRequest(UUID.randomUUID(), customerId, RentalRequestStatus.REVIEWING);
+        when(loadRentalRequestPort.loadByCustomerId(customerId)).thenReturn(List.of(r1, r2));
+
+        List<RentalRequest> result = service.getMyRentalRequests(customerId);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allMatch(r -> r.getCustomerId().equals(customerId));
+    }
+
+    // ── getAllRentalRequests ───────────────────────────────────────────────────
+
+    @Test
+    void getAllRentalRequests_returnsAll() {
+        when(loadRentalRequestPort.loadAll()).thenReturn(
+                List.of(rentalRequest(UUID.randomUUID(), UUID.randomUUID(), RentalRequestStatus.REQUESTED)));
+
+        List<RentalRequest> result = service.getAllRentalRequests();
+
+        assertThat(result).hasSize(1);
+    }
+
+    // ── updateStatus ──────────────────────────────────────────────────────────
+
+    @Test
+    void updateStatus_updatesAndSaves() {
+        UUID requestId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        RentalRequest existing = rentalRequest(requestId, customerId, RentalRequestStatus.REQUESTED);
+        RentalRequest updated = existing.withStatus(RentalRequestStatus.REVIEWING);
+        when(loadRentalRequestPort.loadById(requestId)).thenReturn(Optional.of(existing));
+        when(saveRentalRequestPort.save(any())).thenReturn(updated);
+
+        RentalRequest result = service.updateStatus(requestId, RentalRequestStatus.REVIEWING);
+
+        assertThat(result.getStatus()).isEqualTo(RentalRequestStatus.REVIEWING);
+        verify(saveRentalRequestPort).save(any(RentalRequest.class));
+    }
+
+    @Test
+    void updateStatus_notFound_throwsNotFoundException() {
+        UUID requestId = UUID.randomUUID();
+        when(loadRentalRequestPort.loadById(requestId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateStatus(requestId, RentalRequestStatus.REVIEWING))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private RentalRequest rentalRequest(UUID id, UUID customerId, RentalRequestStatus status) {
+        return new RentalRequest(
+                id, customerId, null, null, null, null, null, null,
+                1, null, status, Instant.now(), Instant.now());
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/ViewingAppointmentServiceTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/ViewingAppointmentServiceTest.java
@@ -1,0 +1,217 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+import vn.edu.hcmus.homestay.application.port.in.CreateViewingAppointmentUseCase.CreateViewingAppointmentCommand;
+import vn.edu.hcmus.homestay.application.port.in.UpdateViewingAppointmentUseCase.RecordOutcomeCommand;
+import vn.edu.hcmus.homestay.application.port.in.UpdateViewingAppointmentUseCase.UpdateAppointmentCommand;
+import vn.edu.hcmus.homestay.application.port.out.LoadRentalRequestPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadViewingAppointmentPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveViewingAppointmentPort;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequestStatus;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointment;
+import vn.edu.hcmus.homestay.domain.model.viewing.ViewingAppointmentStatus;
+
+@ExtendWith(MockitoExtension.class)
+class ViewingAppointmentServiceTest {
+
+    @Mock
+    private LoadViewingAppointmentPort loadViewingAppointmentPort;
+
+    @Mock
+    private SaveViewingAppointmentPort saveViewingAppointmentPort;
+
+    @Mock
+    private LoadRentalRequestPort loadRentalRequestPort;
+
+    private ViewingAppointmentService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ViewingAppointmentService(
+                loadViewingAppointmentPort, saveViewingAppointmentPort, loadRentalRequestPort);
+    }
+
+    // ── createViewingAppointment ──────────────────────────────────────────────
+
+    @Test
+    void createViewingAppointment_rentalRequestNotFound_throws() {
+        UUID rentalRequestId = UUID.randomUUID();
+        when(loadRentalRequestPort.loadById(rentalRequestId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createViewingAppointment(
+                        new CreateViewingAppointmentCommand(
+                                rentalRequestId, UUID.randomUUID(), null, null, null, Instant.now())))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void createViewingAppointment_valid_saves() {
+        UUID rentalRequestId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        RentalRequest rentalRequest = rentalRequest(rentalRequestId, customerId);
+        ViewingAppointment saved = appointment(UUID.randomUUID(), rentalRequestId, customerId, ViewingAppointmentStatus.SCHEDULED);
+
+        when(loadRentalRequestPort.loadById(rentalRequestId)).thenReturn(Optional.of(rentalRequest));
+        when(saveViewingAppointmentPort.save(any())).thenReturn(saved);
+
+        ViewingAppointment result = service.createViewingAppointment(
+                new CreateViewingAppointmentCommand(
+                        rentalRequestId, customerId, null, null, null, Instant.now()));
+
+        assertThat(result.getStatus()).isEqualTo(ViewingAppointmentStatus.SCHEDULED);
+        verify(saveViewingAppointmentPort).save(any(ViewingAppointment.class));
+    }
+
+    // ── getViewingAppointment ─────────────────────────────────────────────────
+
+    @Test
+    void getViewingAppointment_notFound_throwsNotFoundException() {
+        UUID id = UUID.randomUUID();
+        when(loadViewingAppointmentPort.loadById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getViewingAppointment(id))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── cancelAppointment ─────────────────────────────────────────────────────
+
+    @Test
+    void cancelAppointment_setsCancelledStatus() {
+        UUID id = UUID.randomUUID();
+        UUID rentalRequestId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        ViewingAppointment existing = appointment(id, rentalRequestId, customerId, ViewingAppointmentStatus.SCHEDULED);
+        ViewingAppointment cancelled = existing.withStatus(ViewingAppointmentStatus.CANCELLED);
+
+        when(loadViewingAppointmentPort.loadById(id)).thenReturn(Optional.of(existing));
+        when(saveViewingAppointmentPort.save(any())).thenReturn(cancelled);
+
+        ViewingAppointment result = service.cancelAppointment(id);
+
+        assertThat(result.getStatus()).isEqualTo(ViewingAppointmentStatus.CANCELLED);
+        verify(saveViewingAppointmentPort).save(any(ViewingAppointment.class));
+    }
+
+    // ── recordOutcome ─────────────────────────────────────────────────────────
+
+    @Test
+    void recordOutcome_setsStatusAndNote() {
+        UUID id = UUID.randomUUID();
+        UUID rentalRequestId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        ViewingAppointment existing = appointment(id, rentalRequestId, customerId, ViewingAppointmentStatus.SCHEDULED);
+        ViewingAppointment completed = existing.withOutcome("Room looks good", ViewingAppointmentStatus.COMPLETED);
+
+        when(loadViewingAppointmentPort.loadById(id)).thenReturn(Optional.of(existing));
+        when(saveViewingAppointmentPort.save(any())).thenReturn(completed);
+
+        ViewingAppointment result = service.recordOutcome(
+                id, new RecordOutcomeCommand("Room looks good", ViewingAppointmentStatus.COMPLETED));
+
+        assertThat(result.getStatus()).isEqualTo(ViewingAppointmentStatus.COMPLETED);
+        assertThat(result.getResultNote()).isEqualTo("Room looks good");
+        verify(saveViewingAppointmentPort).save(any(ViewingAppointment.class));
+    }
+
+    // ── getAllViewingAppointments ──────────────────────────────────────────────
+
+    @Test
+    void getAllViewingAppointments_returnsAll() {
+        UUID id = UUID.randomUUID();
+        when(loadViewingAppointmentPort.loadAll())
+                .thenReturn(List.of(appointment(id, UUID.randomUUID(), UUID.randomUUID(),
+                        ViewingAppointmentStatus.SCHEDULED)));
+
+        List<ViewingAppointment> result = service.getAllViewingAppointments();
+
+        assertThat(result).hasSize(1);
+    }
+
+    // ── cancelAppointment — not found ─────────────────────────────────────────
+
+    @Test
+    void cancelAppointment_notFound_throwsNotFoundException() {
+        UUID id = UUID.randomUUID();
+        when(loadViewingAppointmentPort.loadById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.cancelAppointment(id))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── recordOutcome — not found ─────────────────────────────────────────────
+
+    @Test
+    void recordOutcome_notFound_throwsNotFoundException() {
+        UUID id = UUID.randomUUID();
+        when(loadViewingAppointmentPort.loadById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.recordOutcome(
+                        id, new RecordOutcomeCommand("note", ViewingAppointmentStatus.COMPLETED)))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── updateAppointment ─────────────────────────────────────────────────────
+
+    @Test
+    void updateAppointment_updatesFields() {
+        UUID id = UUID.randomUUID();
+        UUID rentalRequestId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID newSaleId = UUID.randomUUID();
+        Instant newTime = Instant.parse("2026-08-01T10:00:00Z");
+        ViewingAppointment existing = appointment(id, rentalRequestId, customerId,
+                ViewingAppointmentStatus.SCHEDULED);
+        ViewingAppointment updated = existing.withUpdates(newSaleId, null, null, newTime);
+
+        when(loadViewingAppointmentPort.loadById(id)).thenReturn(Optional.of(existing));
+        when(saveViewingAppointmentPort.save(any())).thenReturn(updated);
+
+        ViewingAppointment result = service.updateAppointment(
+                id, new UpdateAppointmentCommand(newSaleId, null, null, newTime));
+
+        assertThat(result.getSaleId()).isEqualTo(newSaleId);
+        assertThat(result.getScheduledAt()).isEqualTo(newTime);
+        verify(saveViewingAppointmentPort).save(any(ViewingAppointment.class));
+    }
+
+    @Test
+    void updateAppointment_notFound_throwsNotFoundException() {
+        UUID id = UUID.randomUUID();
+        when(loadViewingAppointmentPort.loadById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateAppointment(
+                        id, new UpdateAppointmentCommand(null, null, null, null)))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private RentalRequest rentalRequest(UUID id, UUID customerId) {
+        return new RentalRequest(
+                id, customerId, null, null, null, null, null, null,
+                1, null, RentalRequestStatus.REQUESTED, Instant.now(), Instant.now());
+    }
+
+    private ViewingAppointment appointment(
+            UUID id, UUID rentalRequestId, UUID customerId, ViewingAppointmentStatus status) {
+        return new ViewingAppointment(
+                id, rentalRequestId, customerId, null, null, null,
+                Instant.now(), null, status, Instant.now(), Instant.now());
+    }
+}

--- a/docs/tasks/06-01-backend-spring-boot-migration.md
+++ b/docs/tasks/06-01-backend-spring-boot-migration.md
@@ -63,13 +63,22 @@ gate in app code / Spring Security → produce a **table → access-rule matrix*
 per-role tests.
 **Exit:** access-control matrix documented + tested. *This phase proves security parity.*
 
-### Phase 3 — Catalog / inventory
+### Phase 3 — Catalog / inventory ✅
 `branch`, `zone`, `room`, `bed` (read-heavy, referenced by everything else).
-**Exit:** endpoint parity for all four via the harness.
+HTTP method-scoped GET permitAll in SecurityConfig; writes require auth.
+`StringListConverter` handles PostgreSQL TEXT[] arrays losslessly.
+**Exit:** endpoint parity for all four via the harness. ✅ PR #96
 
-### Phase 4 — UC1 inquiry
+### Phase 4 — UC1 inquiry ✅
 `rental-request`, `viewing-appointments`.
-**Exit:** parity + inquiry flow tests.
+
+Key decisions locked in issue #79:
+- Own-row auth enforced in service layer (owner || staff) — not SpEL
+- `/my-requests` literal path resolves before `/{UUID id}` by Spring MVC specificity
+- State machine transitions documented as `VALID_TRANSITIONS` constant; free-form updates match Express
+- Nullable FKs stored as raw `UUID` fields in domain model; no eager loading
+
+**Exit:** parity + inquiry flow tests. ✅ PR #97 (pending)
 
 ### Phase 5 — UC2 deposit & payment
 `deposit`, `payment` (VietQR), `my-booking`.


### PR DESCRIPTION

## Summary

Ports the UC1 inquiry flow — `rental_requests` and `viewing_appointments` — from Express to Spring Boot, following the hexagonal architecture from Phases 1–3. Customers submit rental requests; Sales staff schedules and records viewing appointments. Phase 4 is the gateway to deposit and contract flows.

Closes #79

## Related References

- Issue: #79
- Epic: #72 (Spring Boot migration)
- Task doc: `docs/tasks/06-01-backend-spring-boot-migration.md` (Phase 4 ✅)
- UC: `docs/UC/UC1.md` — UC1-1, UC1-2, UC1-3

## What Changed

- [x] Backend — Spring Boot: 2 new domain slices (rental-request, viewing-appointments)
- [ ] Frontend — no changes
- [ ] Database / Supabase — no new migration (tables exist in `001_initial_schema.sql`)
- [x] Documentation — migration task doc Phase 3 ✅ + Phase 4 details; README domain layout updated
- [x] Tests — 36 tests: 9+10 service tests, 9+8 controller tests

## Implementation Notes

**Architecture decisions applied (locked in issue #79):**
- Own-row auth enforced in service layer after entity load — `owner || staff`; not SpEL
- `/my-requests` literal path resolves before `/{UUID id}` by Spring MVC specificity
- State machine `VALID_TRANSITIONS` constant in `RentalRequestStatus` — documented, not yet enforced (matches Express parity)
- Nullable FKs (`branch_id`, `room_id`, `bed_id`, `sale_id`) stored as raw `UUID` fields; no eager loading

**Status enums (match DB exactly):**
- `rental_request_status`: 8 values — REQUESTED → REVIEWING → VIEWING_SCHEDULED → ACCEPTED/REJECTED/CANCELLED, DEPOSIT_PENDING → COMPLETED
- `viewing_appointment_status`: 4 values — SCHEDULED, COMPLETED, CANCELLED, NO_SHOW

## Source Of Truth Check

- [ ] `docs/architecture/api-endpoints.md` — not updated (URL shapes differ from original; deferred)
- [ ] `docs/architecture/database.md` — no new tables
- [x] `docs/tasks/06-01-backend-spring-boot-migration.md` — Phase 3 ✅ + Phase 4 ✅
- [ ] `docs/SUC/...` — not applicable
- [x] `backend-spring/README.md` — phases 0–4 listed, domain layout updated

## Verification

```bash
cd backend-spring
./gradlew clean build   # lint + compile + 36 new tests green
```

## Checklist

- [x] I tested the changed behavior locally
- [x] I updated docs if behavior, routes, schema, or setup changed
- [x] I did not leave stale route, model, or enum names behind
- [x] I kept issue/task/docs naming consistent with the current source of truth
- [x] I added or updated tests where the change has meaningful risk

## Breaking Changes

None. All new endpoints; no existing routes modified.

## Follow-Up Work

- Phase 5: deposit & payment (UC2) — depends on Phase 4 rental-request
- `ParityHarnessTest`: extend with rental-request and viewing-appointment endpoints
- State machine transition enforcement when parity is verified
