### PR TITLE
feat(backend-spring): Phase 5 — deposit, payment, my-booking, VietQR (#80)

### DIFF
--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/scheduler/DepositExpiryScheduler.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/scheduler/DepositExpiryScheduler.java
@@ -1,0 +1,49 @@
+package vn.edu.hcmus.homestay.adapter.in.scheduler;
+
+import java.time.Instant;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.application.port.out.LoadDepositPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveDepositPort;
+import vn.edu.hcmus.homestay.common.event.DepositExpiredEvent;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositStatus;
+
+@Component
+public class DepositExpiryScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(DepositExpiryScheduler.class);
+
+    private final LoadDepositPort loadDepositPort;
+    private final SaveDepositPort saveDepositPort;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public DepositExpiryScheduler(
+            LoadDepositPort loadDepositPort,
+            SaveDepositPort saveDepositPort,
+            ApplicationEventPublisher eventPublisher) {
+        this.loadDepositPort = loadDepositPort;
+        this.saveDepositPort = saveDepositPort;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional
+    public void expireOverdueDeposits() {
+        List<DepositRequest> overdue = loadDepositPort.loadPendingExpired(Instant.now());
+        if (overdue.isEmpty()) {
+            return;
+        }
+        log.info("Expiring {} overdue deposit(s)", overdue.size());
+        for (DepositRequest deposit : overdue) {
+            DepositRequest expired = deposit.withStatus(DepositStatus.EXPIRED);
+            saveDepositPort.save(expired);
+            eventPublisher.publishEvent(new DepositExpiredEvent(deposit.getRoomId(), deposit.getBedId()));
+        }
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/DepositController.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/DepositController.java
@@ -1,0 +1,94 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import vn.edu.hcmus.homestay.adapter.in.security.UserPrincipal;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.ConfirmDepositRequest;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.CreateDepositRequest;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.DepositResponse;
+import vn.edu.hcmus.homestay.application.port.in.CancelDepositUseCase;
+import vn.edu.hcmus.homestay.application.port.in.ConfirmDepositUseCase;
+import vn.edu.hcmus.homestay.application.port.in.CreateDepositUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetDepositUseCase;
+import vn.edu.hcmus.homestay.common.ApiResponse;
+import vn.edu.hcmus.homestay.common.ApiResponseBuilder;
+
+@RestController
+@RequestMapping("/api/deposits")
+@PreAuthorize("hasAnyRole('SALE','ACCOUNTANT','MANAGER','ADMIN')")
+public class DepositController {
+
+    private final CreateDepositUseCase createDepositUseCase;
+    private final GetDepositUseCase getDepositUseCase;
+    private final ConfirmDepositUseCase confirmDepositUseCase;
+    private final CancelDepositUseCase cancelDepositUseCase;
+
+    public DepositController(
+            CreateDepositUseCase createDepositUseCase,
+            GetDepositUseCase getDepositUseCase,
+            ConfirmDepositUseCase confirmDepositUseCase,
+            CancelDepositUseCase cancelDepositUseCase) {
+        this.createDepositUseCase = createDepositUseCase;
+        this.getDepositUseCase = getDepositUseCase;
+        this.confirmDepositUseCase = confirmDepositUseCase;
+        this.cancelDepositUseCase = cancelDepositUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<DepositResponse>> createDeposit(
+            @Valid @RequestBody CreateDepositRequest req,
+            @AuthenticationPrincipal UserPrincipal principal) {
+        DepositResponse data = DepositResponse.from(
+                createDepositUseCase.createDeposit(
+                        new CreateDepositUseCase.CreateDepositCommand(
+                                req.getRentalRequestId(),
+                                principal.getId(),
+                                req.getRoomId(),
+                                req.getBedId(),
+                                req.getAmount(),
+                                req.getPaymentMethod(),
+                                req.getNotes())));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<DepositResponse>>> getAllDeposits() {
+        List<DepositResponse> data = getDepositUseCase.getAllDeposits().stream()
+                .map(DepositResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<DepositResponse>> getDeposit(@PathVariable UUID id) {
+        DepositResponse data = DepositResponse.from(getDepositUseCase.getDeposit(id));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @PatchMapping("/{id}/confirm")
+    public ResponseEntity<ApiResponse<DepositResponse>> confirmDeposit(
+            @PathVariable UUID id, @Valid @RequestBody ConfirmDepositRequest req) {
+        DepositResponse data = DepositResponse.from(
+                confirmDepositUseCase.confirmDeposit(
+                        id, new ConfirmDepositUseCase.ConfirmDepositCommand(req.getPaymentMethod())));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @PatchMapping("/{id}/cancel")
+    public ResponseEntity<ApiResponse<DepositResponse>> cancelDeposit(@PathVariable UUID id) {
+        DepositResponse data = DepositResponse.from(cancelDepositUseCase.cancelDeposit(id));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/MyBookingController.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/MyBookingController.java
@@ -1,0 +1,79 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import vn.edu.hcmus.homestay.adapter.in.security.UserPrincipal;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.MyBookingResponse;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.SubmitProofRequest;
+import vn.edu.hcmus.homestay.application.port.in.GetMyBookingUseCase;
+import vn.edu.hcmus.homestay.common.ApiResponse;
+import vn.edu.hcmus.homestay.common.ApiResponseBuilder;
+
+@RestController
+@RequestMapping("/api/my-booking")
+@PreAuthorize("isAuthenticated()")
+public class MyBookingController {
+
+    private final GetMyBookingUseCase getMyBookingUseCase;
+
+    public MyBookingController(GetMyBookingUseCase getMyBookingUseCase) {
+        this.getMyBookingUseCase = getMyBookingUseCase;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<MyBookingResponse>>> getMyBookings(
+            @RequestParam(required = false) String status,
+            @AuthenticationPrincipal UserPrincipal principal) {
+        List<MyBookingResponse> data = getMyBookingUseCase
+                .getMyBookings(principal.getId(), status)
+                .stream()
+                .map(MyBookingResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<MyBookingResponse>> getMyBooking(
+            @PathVariable UUID id, @AuthenticationPrincipal UserPrincipal principal) {
+        MyBookingResponse data = MyBookingResponse.from(
+                getMyBookingUseCase.getMyBooking(id, principal.getId()));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @GetMapping("/{id}/check-availability")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkAvailability(
+            @PathVariable UUID id, @AuthenticationPrincipal UserPrincipal principal) {
+        boolean available = getMyBookingUseCase.checkAvailability(id, principal.getId());
+        return ResponseEntity.ok(ApiResponseBuilder.success(Map.of("isAvailable", available)));
+    }
+
+    @PostMapping("/{id}/cancel")
+    public ResponseEntity<ApiResponse<MyBookingResponse>> cancelBooking(
+            @PathVariable UUID id, @AuthenticationPrincipal UserPrincipal principal) {
+        MyBookingResponse data = MyBookingResponse.from(
+                getMyBookingUseCase.cancelBooking(id, principal.getId()));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+
+    @PostMapping("/{id}/submit-proof")
+    public ResponseEntity<ApiResponse<MyBookingResponse>> submitProof(
+            @PathVariable UUID id,
+            @Valid @RequestBody SubmitProofRequest req,
+            @AuthenticationPrincipal UserPrincipal principal) {
+        MyBookingResponse data = MyBookingResponse.from(
+                getMyBookingUseCase.submitProof(id, principal.getId(), req.getProofImageUrl()));
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/PaymentController.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/PaymentController.java
@@ -1,0 +1,32 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import vn.edu.hcmus.homestay.adapter.in.web.dto.PaymentResponse;
+import vn.edu.hcmus.homestay.application.port.in.GetPaymentUseCase;
+import vn.edu.hcmus.homestay.common.ApiResponse;
+import vn.edu.hcmus.homestay.common.ApiResponseBuilder;
+
+@RestController
+@RequestMapping("/api/payments")
+@PreAuthorize("hasAnyRole('SALE','ACCOUNTANT','MANAGER','ADMIN')")
+public class PaymentController {
+
+    private final GetPaymentUseCase getPaymentUseCase;
+
+    public PaymentController(GetPaymentUseCase getPaymentUseCase) {
+        this.getPaymentUseCase = getPaymentUseCase;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PaymentResponse>>> getAllPayments() {
+        List<PaymentResponse> data = getPaymentUseCase.getAllPayments().stream()
+                .map(PaymentResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponseBuilder.success(data));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/ConfirmDepositRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/ConfirmDepositRequest.java
@@ -1,0 +1,20 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentMethod;
+
+public class ConfirmDepositRequest {
+
+    @NotNull
+    @JsonProperty("payment_method")
+    private PaymentMethod paymentMethod;
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateDepositRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/CreateDepositRequest.java
@@ -1,0 +1,77 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentMethod;
+
+public class CreateDepositRequest {
+
+    @JsonProperty("rental_request_id")
+    private UUID rentalRequestId;
+
+    @NotNull
+    @JsonProperty("room_id")
+    private UUID roomId;
+
+    @JsonProperty("bed_id")
+    private UUID bedId;
+
+    @NotNull
+    private BigDecimal amount;
+
+    @NotNull
+    @JsonProperty("payment_method")
+    private PaymentMethod paymentMethod;
+
+    private String notes;
+
+    public UUID getRentalRequestId() {
+        return rentalRequestId;
+    }
+
+    public void setRentalRequestId(UUID rentalRequestId) {
+        this.rentalRequestId = rentalRequestId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public void setBedId(UUID bedId) {
+        this.bedId = bedId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/DepositResponse.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/DepositResponse.java
@@ -1,0 +1,179 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+
+public class DepositResponse {
+
+    private UUID id;
+
+    @JsonProperty("rental_request_id")
+    private UUID rentalRequestId;
+
+    @JsonProperty("customer_id")
+    private UUID customerId;
+
+    @JsonProperty("room_id")
+    private UUID roomId;
+
+    @JsonProperty("bed_id")
+    private UUID bedId;
+
+    private BigDecimal amount;
+
+    @JsonProperty("due_at")
+    private Instant dueAt;
+
+    @JsonProperty("paid_at")
+    private Instant paidAt;
+
+    @JsonProperty("proof_image_url")
+    private String proofImageUrl;
+
+    @JsonProperty("vietqr_reference")
+    private String vietqrReference;
+
+    private String notes;
+
+    private String status;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("updated_at")
+    private Instant updatedAt;
+
+    public static DepositResponse from(DepositRequest d) {
+        DepositResponse r = new DepositResponse();
+        r.id = d.getId();
+        r.rentalRequestId = d.getRentalRequestId();
+        r.customerId = d.getCustomerId();
+        r.roomId = d.getRoomId();
+        r.bedId = d.getBedId();
+        r.amount = d.getAmount();
+        r.dueAt = d.getDueAt();
+        r.paidAt = d.getPaidAt();
+        r.proofImageUrl = d.getProofImageUrl();
+        r.vietqrReference = d.getVietqrReference();
+        r.notes = d.getNotes();
+        r.status = d.getStatus() != null ? d.getStatus().name().toLowerCase() : null;
+        r.createdAt = d.getCreatedAt();
+        r.updatedAt = d.getUpdatedAt();
+        return r;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getRentalRequestId() {
+        return rentalRequestId;
+    }
+
+    public void setRentalRequestId(UUID rentalRequestId) {
+        this.rentalRequestId = rentalRequestId;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+        this.customerId = customerId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public void setBedId(UUID bedId) {
+        this.bedId = bedId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public Instant getDueAt() {
+        return dueAt;
+    }
+
+    public void setDueAt(Instant dueAt) {
+        this.dueAt = dueAt;
+    }
+
+    public Instant getPaidAt() {
+        return paidAt;
+    }
+
+    public void setPaidAt(Instant paidAt) {
+        this.paidAt = paidAt;
+    }
+
+    public String getProofImageUrl() {
+        return proofImageUrl;
+    }
+
+    public void setProofImageUrl(String proofImageUrl) {
+        this.proofImageUrl = proofImageUrl;
+    }
+
+    public String getVietqrReference() {
+        return vietqrReference;
+    }
+
+    public void setVietqrReference(String vietqrReference) {
+        this.vietqrReference = vietqrReference;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/MyBookingResponse.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/MyBookingResponse.java
@@ -1,0 +1,228 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.mybooking.MyBooking;
+
+public class MyBookingResponse {
+
+    private UUID id;
+
+    @JsonProperty("customer_id")
+    private UUID customerId;
+
+    @JsonProperty("branch_name")
+    private String branchName;
+
+    @JsonProperty("branch_address")
+    private String branchAddress;
+
+    @JsonProperty("room_number")
+    private String roomNumber;
+
+    @JsonProperty("room_type")
+    private String roomType;
+
+    @JsonProperty("price_per_month")
+    private BigDecimal pricePerMonth;
+
+    @JsonProperty("bed_number")
+    private String bedNumber;
+
+    @JsonProperty("people_count")
+    private int peopleCount;
+
+    private String note;
+
+    private String status;
+
+    @JsonProperty("deposit_id")
+    private UUID depositId;
+
+    @JsonProperty("deposit_amount")
+    private BigDecimal depositAmount;
+
+    @JsonProperty("deposit_status")
+    private String depositStatus;
+
+    @JsonProperty("deposit_due_at")
+    private Instant depositDueAt;
+
+    @JsonProperty("vietqr_reference")
+    private String vietqrReference;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("updated_at")
+    private Instant updatedAt;
+
+    public static MyBookingResponse from(MyBooking b) {
+        MyBookingResponse r = new MyBookingResponse();
+        r.id = b.getId();
+        r.customerId = b.getCustomerId();
+        r.branchName = b.getBranchName();
+        r.branchAddress = b.getBranchAddress();
+        r.roomNumber = b.getRoomNumber();
+        r.roomType = b.getRoomType();
+        r.pricePerMonth = b.getPricePerMonth();
+        r.bedNumber = b.getBedNumber();
+        r.peopleCount = b.getPeopleCount();
+        r.note = b.getNote();
+        r.status = b.getStatus();
+        r.depositId = b.getDepositId();
+        r.depositAmount = b.getDepositAmount();
+        r.depositStatus = b.getDepositStatus();
+        r.depositDueAt = b.getDepositDueAt();
+        r.vietqrReference = b.getVietqrReference();
+        r.createdAt = b.getCreatedAt();
+        r.updatedAt = b.getUpdatedAt();
+        return r;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+        this.customerId = customerId;
+    }
+
+    public String getBranchName() {
+        return branchName;
+    }
+
+    public void setBranchName(String branchName) {
+        this.branchName = branchName;
+    }
+
+    public String getBranchAddress() {
+        return branchAddress;
+    }
+
+    public void setBranchAddress(String branchAddress) {
+        this.branchAddress = branchAddress;
+    }
+
+    public String getRoomNumber() {
+        return roomNumber;
+    }
+
+    public void setRoomNumber(String roomNumber) {
+        this.roomNumber = roomNumber;
+    }
+
+    public String getRoomType() {
+        return roomType;
+    }
+
+    public void setRoomType(String roomType) {
+        this.roomType = roomType;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public void setPricePerMonth(BigDecimal pricePerMonth) {
+        this.pricePerMonth = pricePerMonth;
+    }
+
+    public String getBedNumber() {
+        return bedNumber;
+    }
+
+    public void setBedNumber(String bedNumber) {
+        this.bedNumber = bedNumber;
+    }
+
+    public int getPeopleCount() {
+        return peopleCount;
+    }
+
+    public void setPeopleCount(int peopleCount) {
+        this.peopleCount = peopleCount;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public void setNote(String note) {
+        this.note = note;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public UUID getDepositId() {
+        return depositId;
+    }
+
+    public void setDepositId(UUID depositId) {
+        this.depositId = depositId;
+    }
+
+    public BigDecimal getDepositAmount() {
+        return depositAmount;
+    }
+
+    public void setDepositAmount(BigDecimal depositAmount) {
+        this.depositAmount = depositAmount;
+    }
+
+    public String getDepositStatus() {
+        return depositStatus;
+    }
+
+    public void setDepositStatus(String depositStatus) {
+        this.depositStatus = depositStatus;
+    }
+
+    public Instant getDepositDueAt() {
+        return depositDueAt;
+    }
+
+    public void setDepositDueAt(Instant depositDueAt) {
+        this.depositDueAt = depositDueAt;
+    }
+
+    public String getVietqrReference() {
+        return vietqrReference;
+    }
+
+    public void setVietqrReference(String vietqrReference) {
+        this.vietqrReference = vietqrReference;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/PaymentResponse.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/PaymentResponse.java
@@ -1,0 +1,180 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.payment.Payment;
+
+public class PaymentResponse {
+
+    private UUID id;
+
+    @JsonProperty("user_id")
+    private UUID userId;
+
+    @JsonProperty("deposit_request_id")
+    private UUID depositRequestId;
+
+    @JsonProperty("contract_id")
+    private UUID contractId;
+
+    @JsonProperty("settlement_id")
+    private UUID settlementId;
+
+    private BigDecimal amount;
+
+    private String type;
+
+    private String status;
+
+    @JsonProperty("payment_method")
+    private String paymentMethod;
+
+    @JsonProperty("vietqr_reference")
+    private String vietqrReference;
+
+    @JsonProperty("proof_image_url")
+    private String proofImageUrl;
+
+    private String notes;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("updated_at")
+    private Instant updatedAt;
+
+    public static PaymentResponse from(Payment p) {
+        PaymentResponse r = new PaymentResponse();
+        r.id = p.getId();
+        r.userId = p.getUserId();
+        r.depositRequestId = p.getDepositRequestId();
+        r.contractId = p.getContractId();
+        r.settlementId = p.getSettlementId();
+        r.amount = p.getAmount();
+        r.type = p.getType() != null ? p.getType().name().toLowerCase() : null;
+        r.status = p.getStatus() != null ? p.getStatus().name().toLowerCase() : null;
+        r.paymentMethod = p.getPaymentMethod() != null
+                ? p.getPaymentMethod().name().toLowerCase()
+                : null;
+        r.vietqrReference = p.getVietqrReference();
+        r.proofImageUrl = p.getProofImageUrl();
+        r.notes = p.getNotes();
+        r.createdAt = p.getCreatedAt();
+        r.updatedAt = p.getUpdatedAt();
+        return r;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public UUID getDepositRequestId() {
+        return depositRequestId;
+    }
+
+    public void setDepositRequestId(UUID depositRequestId) {
+        this.depositRequestId = depositRequestId;
+    }
+
+    public UUID getContractId() {
+        return contractId;
+    }
+
+    public void setContractId(UUID contractId) {
+        this.contractId = contractId;
+    }
+
+    public UUID getSettlementId() {
+        return settlementId;
+    }
+
+    public void setSettlementId(UUID settlementId) {
+        this.settlementId = settlementId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(String paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public String getVietqrReference() {
+        return vietqrReference;
+    }
+
+    public void setVietqrReference(String vietqrReference) {
+        this.vietqrReference = vietqrReference;
+    }
+
+    public String getProofImageUrl() {
+        return proofImageUrl;
+    }
+
+    public void setProofImageUrl(String proofImageUrl) {
+        this.proofImageUrl = proofImageUrl;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/SubmitProofRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/in/web/dto/SubmitProofRequest.java
@@ -1,0 +1,19 @@
+package vn.edu.hcmus.homestay.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public class SubmitProofRequest {
+
+    @NotBlank
+    @JsonProperty("proof_image_url")
+    private String proofImageUrl;
+
+    public String getProofImageUrl() {
+        return proofImageUrl;
+    }
+
+    public void setProofImageUrl(String proofImageUrl) {
+        this.proofImageUrl = proofImageUrl;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/DepositPersistenceAdapter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/DepositPersistenceAdapter.java
@@ -1,0 +1,47 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.application.port.out.LoadDepositPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveDepositPort;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositStatus;
+
+@Component
+class DepositPersistenceAdapter implements LoadDepositPort, SaveDepositPort {
+
+    private final DepositRequestJpaRepository jpaRepository;
+    private final DepositRequestMapper mapper;
+
+    DepositPersistenceAdapter(DepositRequestJpaRepository jpaRepository, DepositRequestMapper mapper) {
+        this.jpaRepository = jpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Optional<DepositRequest> loadById(UUID id) {
+        return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public List<DepositRequest> loadAll() {
+        return jpaRepository.findAll().stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public List<DepositRequest> loadPendingExpired(Instant now) {
+        return jpaRepository
+                .findByStatusAndDueAtBefore(DepositStatus.PENDING, now)
+                .stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public DepositRequest save(DepositRequest deposit) {
+        return mapper.toDomain(jpaRepository.save(mapper.toEntity(deposit)));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/DepositRequestEntity.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/DepositRequestEntity.java
@@ -1,0 +1,137 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositStatus;
+
+@Entity
+@Table(name = "deposit_requests", schema = "public")
+public class DepositRequestEntity extends BaseEntity {
+
+    @Column(name = "rental_request_id")
+    private UUID rentalRequestId;
+
+    @Column(name = "customer_id", nullable = false)
+    private UUID customerId;
+
+    @Column(name = "room_id", nullable = false)
+    private UUID roomId;
+
+    @Column(name = "bed_id")
+    private UUID bedId;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Column(name = "due_at", nullable = false)
+    private Instant dueAt;
+
+    @Column(name = "paid_at")
+    private Instant paidAt;
+
+    @Column(name = "proof_image_url")
+    private String proofImageUrl;
+
+    @Column(name = "vietqr_reference")
+    private String vietqrReference;
+
+    @Column
+    private String notes;
+
+    @Convert(converter = DepositStatusConverter.class)
+    @Column(nullable = false)
+    private DepositStatus status;
+
+    public UUID getRentalRequestId() {
+        return rentalRequestId;
+    }
+
+    public void setRentalRequestId(UUID rentalRequestId) {
+        this.rentalRequestId = rentalRequestId;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+        this.customerId = customerId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(UUID roomId) {
+        this.roomId = roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public void setBedId(UUID bedId) {
+        this.bedId = bedId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public Instant getDueAt() {
+        return dueAt;
+    }
+
+    public void setDueAt(Instant dueAt) {
+        this.dueAt = dueAt;
+    }
+
+    public Instant getPaidAt() {
+        return paidAt;
+    }
+
+    public void setPaidAt(Instant paidAt) {
+        this.paidAt = paidAt;
+    }
+
+    public String getProofImageUrl() {
+        return proofImageUrl;
+    }
+
+    public void setProofImageUrl(String proofImageUrl) {
+        this.proofImageUrl = proofImageUrl;
+    }
+
+    public String getVietqrReference() {
+        return vietqrReference;
+    }
+
+    public void setVietqrReference(String vietqrReference) {
+        this.vietqrReference = vietqrReference;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public DepositStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(DepositStatus status) {
+        this.status = status;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/DepositRequestJpaRepository.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/DepositRequestJpaRepository.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositStatus;
+
+interface DepositRequestJpaRepository extends JpaRepository<DepositRequestEntity, UUID> {
+
+    List<DepositRequestEntity> findByStatusAndDueAtBefore(DepositStatus status, Instant now);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/DepositRequestMapper.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/DepositRequestMapper.java
@@ -1,0 +1,45 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+
+@Component
+class DepositRequestMapper {
+
+    DepositRequest toDomain(DepositRequestEntity e) {
+        return new DepositRequest(
+                e.getId(),
+                e.getRentalRequestId(),
+                e.getCustomerId(),
+                e.getRoomId(),
+                e.getBedId(),
+                e.getAmount(),
+                e.getDueAt(),
+                e.getPaidAt(),
+                e.getProofImageUrl(),
+                e.getVietqrReference(),
+                e.getNotes(),
+                e.getStatus(),
+                e.getCreatedAt(),
+                e.getUpdatedAt());
+    }
+
+    DepositRequestEntity toEntity(DepositRequest d) {
+        DepositRequestEntity e = new DepositRequestEntity();
+        if (d.getId() != null) {
+            e.setId(d.getId());
+        }
+        e.setRentalRequestId(d.getRentalRequestId());
+        e.setCustomerId(d.getCustomerId());
+        e.setRoomId(d.getRoomId());
+        e.setBedId(d.getBedId());
+        e.setAmount(d.getAmount());
+        e.setDueAt(d.getDueAt());
+        e.setPaidAt(d.getPaidAt());
+        e.setProofImageUrl(d.getProofImageUrl());
+        e.setVietqrReference(d.getVietqrReference());
+        e.setNotes(d.getNotes());
+        e.setStatus(d.getStatus());
+        return e;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/DepositStatusConverter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/DepositStatusConverter.java
@@ -1,0 +1,20 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositStatus;
+
+@Converter(autoApply = true)
+public class DepositStatusConverter implements AttributeConverter<DepositStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(DepositStatus status) {
+        return status == null ? null : status.name().toLowerCase();
+    }
+
+    @Override
+    public DepositStatus convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        return DepositStatus.valueOf(dbData.toUpperCase());
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentEntity.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentEntity.java
@@ -1,0 +1,141 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentMethod;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentStatus;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentType;
+
+@Entity
+@Table(name = "payments", schema = "public")
+public class PaymentEntity extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "deposit_request_id")
+    private UUID depositRequestId;
+
+    @Column(name = "contract_id")
+    private UUID contractId;
+
+    @Column(name = "settlement_id")
+    private UUID settlementId;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Convert(converter = PaymentTypeConverter.class)
+    @Column(nullable = false)
+    private PaymentType type;
+
+    @Convert(converter = PaymentStatusConverter.class)
+    @Column(nullable = false)
+    private PaymentStatus status;
+
+    @Convert(converter = PaymentMethodConverter.class)
+    @Column(name = "payment_method", nullable = false)
+    private PaymentMethod paymentMethod;
+
+    @Column(name = "vietqr_reference")
+    private String vietqrReference;
+
+    @Column(name = "proof_image_url")
+    private String proofImageUrl;
+
+    @Column
+    private String notes;
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public UUID getDepositRequestId() {
+        return depositRequestId;
+    }
+
+    public void setDepositRequestId(UUID depositRequestId) {
+        this.depositRequestId = depositRequestId;
+    }
+
+    public UUID getContractId() {
+        return contractId;
+    }
+
+    public void setContractId(UUID contractId) {
+        this.contractId = contractId;
+    }
+
+    public UUID getSettlementId() {
+        return settlementId;
+    }
+
+    public void setSettlementId(UUID settlementId) {
+        this.settlementId = settlementId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public PaymentType getType() {
+        return type;
+    }
+
+    public void setType(PaymentType type) {
+        this.type = type;
+    }
+
+    public PaymentStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(PaymentStatus status) {
+        this.status = status;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public String getVietqrReference() {
+        return vietqrReference;
+    }
+
+    public void setVietqrReference(String vietqrReference) {
+        this.vietqrReference = vietqrReference;
+    }
+
+    public String getProofImageUrl() {
+        return proofImageUrl;
+    }
+
+    public void setProofImageUrl(String proofImageUrl) {
+        this.proofImageUrl = proofImageUrl;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentJpaRepository.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentJpaRepository.java
@@ -1,0 +1,6 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface PaymentJpaRepository extends JpaRepository<PaymentEntity, UUID> {}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentMapper.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentMapper.java
@@ -1,0 +1,45 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.domain.model.payment.Payment;
+
+@Component
+class PaymentMapper {
+
+    Payment toDomain(PaymentEntity e) {
+        return new Payment(
+                e.getId(),
+                e.getUserId(),
+                e.getDepositRequestId(),
+                e.getContractId(),
+                e.getSettlementId(),
+                e.getAmount(),
+                e.getType(),
+                e.getStatus(),
+                e.getPaymentMethod(),
+                e.getVietqrReference(),
+                e.getProofImageUrl(),
+                e.getNotes(),
+                e.getCreatedAt(),
+                e.getUpdatedAt());
+    }
+
+    PaymentEntity toEntity(Payment p) {
+        PaymentEntity e = new PaymentEntity();
+        if (p.getId() != null) {
+            e.setId(p.getId());
+        }
+        e.setUserId(p.getUserId());
+        e.setDepositRequestId(p.getDepositRequestId());
+        e.setContractId(p.getContractId());
+        e.setSettlementId(p.getSettlementId());
+        e.setAmount(p.getAmount());
+        e.setType(p.getType());
+        e.setStatus(p.getStatus());
+        e.setPaymentMethod(p.getPaymentMethod());
+        e.setVietqrReference(p.getVietqrReference());
+        e.setProofImageUrl(p.getProofImageUrl());
+        e.setNotes(p.getNotes());
+        return e;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentMethodConverter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentMethodConverter.java
@@ -1,0 +1,20 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentMethod;
+
+@Converter(autoApply = true)
+public class PaymentMethodConverter implements AttributeConverter<PaymentMethod, String> {
+
+    @Override
+    public String convertToDatabaseColumn(PaymentMethod method) {
+        return method == null ? null : method.name().toLowerCase();
+    }
+
+    @Override
+    public PaymentMethod convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        return PaymentMethod.valueOf(dbData.toUpperCase());
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentPersistenceAdapter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentPersistenceAdapter.java
@@ -1,0 +1,29 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+import vn.edu.hcmus.homestay.application.port.out.LoadPaymentPort;
+import vn.edu.hcmus.homestay.application.port.out.SavePaymentPort;
+import vn.edu.hcmus.homestay.domain.model.payment.Payment;
+
+@Component
+class PaymentPersistenceAdapter implements LoadPaymentPort, SavePaymentPort {
+
+    private final PaymentJpaRepository jpaRepository;
+    private final PaymentMapper mapper;
+
+    PaymentPersistenceAdapter(PaymentJpaRepository jpaRepository, PaymentMapper mapper) {
+        this.jpaRepository = jpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<Payment> loadAll() {
+        return jpaRepository.findAll().stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public Payment save(Payment payment) {
+        return mapper.toDomain(jpaRepository.save(mapper.toEntity(payment)));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentStatusConverter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentStatusConverter.java
@@ -1,0 +1,20 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentStatus;
+
+@Converter(autoApply = true)
+public class PaymentStatusConverter implements AttributeConverter<PaymentStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(PaymentStatus status) {
+        return status == null ? null : status.name().toLowerCase();
+    }
+
+    @Override
+    public PaymentStatus convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        return PaymentStatus.valueOf(dbData.toUpperCase());
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentTypeConverter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/persistence/PaymentTypeConverter.java
@@ -1,0 +1,20 @@
+package vn.edu.hcmus.homestay.adapter.out.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentType;
+
+@Converter(autoApply = true)
+public class PaymentTypeConverter implements AttributeConverter<PaymentType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(PaymentType type) {
+        return type == null ? null : type.name().toLowerCase();
+    }
+
+    @Override
+    public PaymentType convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        return PaymentType.valueOf(dbData.toUpperCase());
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/vietqr/VietQRAdapter.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/adapter/out/vietqr/VietQRAdapter.java
@@ -1,0 +1,80 @@
+package vn.edu.hcmus.homestay.adapter.out.vietqr;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import vn.edu.hcmus.homestay.application.port.out.GenerateVietQRPort;
+
+@Component
+public class VietQRAdapter implements GenerateVietQRPort {
+
+    private static final Logger log = LoggerFactory.getLogger(VietQRAdapter.class);
+    private static final String API_URL = "https://api.vietqr.io/v2/generate";
+
+    @Value("${vietqr.client-id:}")
+    private String clientId;
+
+    @Value("${vietqr.client-secret:}")
+    private String clientSecret;
+
+    @Value("${vietqr.bank-bin:970422}")
+    private String bankBin;
+
+    @Value("${vietqr.account-no:}")
+    private String accountNo;
+
+    @Value("${vietqr.account-name:}")
+    private String accountName;
+
+    @Value("${vietqr.template:compact}")
+    private String template;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Override
+    public String generateQRUrl(BigDecimal amount, String description) {
+        if (clientId.isBlank() || clientSecret.isBlank() || accountNo.isBlank()) {
+            log.warn("VietQR not configured — skipping QR generation");
+            return null;
+        }
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("x-client-id", clientId);
+            headers.set("x-api-key", clientSecret);
+
+            Map<String, Object> body = Map.of(
+                    "accountNo", accountNo,
+                    "accountName", accountName,
+                    "acqId", bankBin,
+                    "amount", amount.intValue(),
+                    "addInfo", description,
+                    "format", "text",
+                    "template", template);
+
+            @SuppressWarnings("rawtypes")
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    API_URL, HttpMethod.POST, new HttpEntity<>(body, headers), Map.class);
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> data = (Map<String, Object>) response.getBody().get("data");
+                if (data != null) {
+                    return (String) data.get("qrDataURL");
+                }
+            }
+        } catch (Exception ex) {
+            log.error("VietQR API call failed ({})", ex.getClass().getSimpleName());
+        }
+        return null;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CancelDepositUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CancelDepositUseCase.java
@@ -1,0 +1,9 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+
+public interface CancelDepositUseCase {
+
+    DepositRequest cancelDeposit(UUID id);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/ConfirmDepositUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/ConfirmDepositUseCase.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentMethod;
+
+public interface ConfirmDepositUseCase {
+
+    DepositRequest confirmDeposit(UUID id, ConfirmDepositCommand command);
+
+    record ConfirmDepositCommand(PaymentMethod paymentMethod) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateDepositUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/CreateDepositUseCase.java
@@ -1,0 +1,20 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentMethod;
+
+public interface CreateDepositUseCase {
+
+    DepositRequest createDeposit(CreateDepositCommand command);
+
+    record CreateDepositCommand(
+            UUID rentalRequestId,
+            UUID customerId,
+            UUID roomId,
+            UUID bedId,
+            BigDecimal amount,
+            PaymentMethod paymentMethod,
+            String notes) {}
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetDepositUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetDepositUseCase.java
@@ -1,0 +1,12 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.List;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+
+public interface GetDepositUseCase {
+
+    DepositRequest getDeposit(UUID id);
+
+    List<DepositRequest> getAllDeposits();
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetMyBookingUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetMyBookingUseCase.java
@@ -1,0 +1,18 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.List;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.mybooking.MyBooking;
+
+public interface GetMyBookingUseCase {
+
+    List<MyBooking> getMyBookings(UUID customerId, String statusFilter);
+
+    MyBooking getMyBooking(UUID bookingId, UUID customerId);
+
+    boolean checkAvailability(UUID bookingId, UUID customerId);
+
+    MyBooking submitProof(UUID bookingId, UUID customerId, String proofImageUrl);
+
+    MyBooking cancelBooking(UUID bookingId, UUID customerId);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetPaymentUseCase.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/in/GetPaymentUseCase.java
@@ -1,0 +1,9 @@
+package vn.edu.hcmus.homestay.application.port.in;
+
+import java.util.List;
+import vn.edu.hcmus.homestay.domain.model.payment.Payment;
+
+public interface GetPaymentUseCase {
+
+    List<Payment> getAllPayments();
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/GenerateVietQRPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/GenerateVietQRPort.java
@@ -1,0 +1,9 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.math.BigDecimal;
+
+public interface GenerateVietQRPort {
+
+    /** Returns the QR data URL (base64 PNG), or null if the API is unavailable. */
+    String generateQRUrl(BigDecimal amount, String description);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadDepositPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadDepositPort.java
@@ -1,0 +1,17 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+
+public interface LoadDepositPort {
+
+    Optional<DepositRequest> loadById(UUID id);
+
+    List<DepositRequest> loadAll();
+
+    /** Returns all PENDING deposits whose dueAt is before the given instant (for the scheduler). */
+    List<DepositRequest> loadPendingExpired(Instant now);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadPaymentPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/LoadPaymentPort.java
@@ -1,0 +1,9 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import java.util.List;
+import vn.edu.hcmus.homestay.domain.model.payment.Payment;
+
+public interface LoadPaymentPort {
+
+    List<Payment> loadAll();
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveDepositPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SaveDepositPort.java
@@ -1,0 +1,8 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+
+public interface SaveDepositPort {
+
+    DepositRequest save(DepositRequest deposit);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SavePaymentPort.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/port/out/SavePaymentPort.java
@@ -1,0 +1,8 @@
+package vn.edu.hcmus.homestay.application.port.out;
+
+import vn.edu.hcmus.homestay.domain.model.payment.Payment;
+
+public interface SavePaymentPort {
+
+    Payment save(Payment payment);
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/CatalogEventHandler.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/CatalogEventHandler.java
@@ -1,0 +1,103 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import vn.edu.hcmus.homestay.application.port.out.LoadBedPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadRoomPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveBedPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveRoomPort;
+import vn.edu.hcmus.homestay.common.event.DepositConfirmedEvent;
+import vn.edu.hcmus.homestay.common.event.DepositExpiredEvent;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+import vn.edu.hcmus.homestay.domain.model.bed.BedStatus;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+import vn.edu.hcmus.homestay.domain.model.room.RoomStatus;
+
+@Component
+public class CatalogEventHandler {
+
+    private final LoadRoomPort loadRoomPort;
+    private final SaveRoomPort saveRoomPort;
+    private final LoadBedPort loadBedPort;
+    private final SaveBedPort saveBedPort;
+
+    public CatalogEventHandler(
+            LoadRoomPort loadRoomPort,
+            SaveRoomPort saveRoomPort,
+            LoadBedPort loadBedPort,
+            SaveBedPort saveBedPort) {
+        this.loadRoomPort = loadRoomPort;
+        this.saveRoomPort = saveRoomPort;
+        this.loadBedPort = loadBedPort;
+        this.saveBedPort = saveBedPort;
+    }
+
+    @EventListener
+    @Transactional
+    public void onDepositConfirmed(DepositConfirmedEvent event) {
+        loadRoomPort.loadById(event.roomId()).ifPresent(room -> {
+            Room updated = new Room(
+                    room.getId(),
+                    room.getBranchId(),
+                    room.getRoomNumber(),
+                    room.getRoomType(),
+                    room.getMaxCapacity(),
+                    room.getPricePerMonth(),
+                    room.getAmenities(),
+                    room.getImagesUrl(),
+                    RoomStatus.DEPOSITED,
+                    room.getCreatedAt(),
+                    room.getUpdatedAt());
+            saveRoomPort.save(updated);
+        });
+
+        if (event.bedId() != null) {
+            loadBedPort.loadById(event.bedId()).ifPresent(bed -> {
+                Bed updated = new Bed(
+                        bed.getId(),
+                        bed.getRoomId(),
+                        bed.getBedNumber(),
+                        bed.getPricePerMonth(),
+                        BedStatus.OCCUPIED,
+                        bed.getCreatedAt(),
+                        bed.getUpdatedAt());
+                saveBedPort.save(updated);
+            });
+        }
+    }
+
+    @EventListener
+    @Transactional
+    public void onDepositExpired(DepositExpiredEvent event) {
+        loadRoomPort.loadById(event.roomId()).ifPresent(room -> {
+            Room updated = new Room(
+                    room.getId(),
+                    room.getBranchId(),
+                    room.getRoomNumber(),
+                    room.getRoomType(),
+                    room.getMaxCapacity(),
+                    room.getPricePerMonth(),
+                    room.getAmenities(),
+                    room.getImagesUrl(),
+                    RoomStatus.AVAILABLE,
+                    room.getCreatedAt(),
+                    room.getUpdatedAt());
+            saveRoomPort.save(updated);
+        });
+
+        if (event.bedId() != null) {
+            loadBedPort.loadById(event.bedId()).ifPresent(bed -> {
+                Bed updated = new Bed(
+                        bed.getId(),
+                        bed.getRoomId(),
+                        bed.getBedNumber(),
+                        bed.getPricePerMonth(),
+                        BedStatus.AVAILABLE,
+                        bed.getCreatedAt(),
+                        bed.getUpdatedAt());
+                saveBedPort.save(updated);
+            });
+        }
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/DepositService.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/DepositService.java
@@ -1,0 +1,129 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import vn.edu.hcmus.homestay.application.port.in.CancelDepositUseCase;
+import vn.edu.hcmus.homestay.application.port.in.ConfirmDepositUseCase;
+import vn.edu.hcmus.homestay.application.port.in.CreateDepositUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetDepositUseCase;
+import vn.edu.hcmus.homestay.application.port.out.GenerateVietQRPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadDepositPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveDepositPort;
+import vn.edu.hcmus.homestay.application.port.out.SavePaymentPort;
+import vn.edu.hcmus.homestay.common.event.DepositConfirmedEvent;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositStatus;
+import vn.edu.hcmus.homestay.domain.model.payment.Payment;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentMethod;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentStatus;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentType;
+
+@Service
+public class DepositService
+        implements CreateDepositUseCase, GetDepositUseCase, ConfirmDepositUseCase, CancelDepositUseCase {
+
+    private final LoadDepositPort loadDepositPort;
+    private final SaveDepositPort saveDepositPort;
+    private final SavePaymentPort savePaymentPort;
+    private final GenerateVietQRPort generateVietQRPort;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public DepositService(
+            LoadDepositPort loadDepositPort,
+            SaveDepositPort saveDepositPort,
+            SavePaymentPort savePaymentPort,
+            GenerateVietQRPort generateVietQRPort,
+            ApplicationEventPublisher eventPublisher) {
+        this.loadDepositPort = loadDepositPort;
+        this.saveDepositPort = saveDepositPort;
+        this.savePaymentPort = savePaymentPort;
+        this.generateVietQRPort = generateVietQRPort;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override
+    @Transactional
+    public DepositRequest createDeposit(CreateDepositCommand command) {
+        Instant now = Instant.now();
+        DepositRequest deposit = new DepositRequest(
+                null,
+                command.rentalRequestId(),
+                command.customerId(),
+                command.roomId(),
+                command.bedId(),
+                command.amount(),
+                now.plus(24, ChronoUnit.HOURS),
+                null,
+                null,
+                null,
+                command.notes(),
+                DepositStatus.PENDING,
+                null,
+                null);
+
+        if (command.paymentMethod() == PaymentMethod.VIETQR) {
+            String qrUrl = generateVietQRPort.generateQRUrl(
+                    command.amount(), "Deposit " + command.roomId());
+            if (qrUrl != null) {
+                deposit = deposit.withVietQRReference(qrUrl);
+            }
+        }
+
+        return saveDepositPort.save(deposit);
+    }
+
+    @Override
+    public DepositRequest getDeposit(UUID id) {
+        return loadDepositPort.loadById(id)
+                .orElseThrow(() -> new NotFoundException("Deposit request not found"));
+    }
+
+    @Override
+    public List<DepositRequest> getAllDeposits() {
+        return loadDepositPort.loadAll();
+    }
+
+    @Override
+    @Transactional
+    public DepositRequest confirmDeposit(UUID id, ConfirmDepositCommand command) {
+        DepositRequest deposit = loadDepositPort.loadById(id)
+                .orElseThrow(() -> new NotFoundException("Deposit request not found"));
+
+        DepositRequest updated = deposit.withStatus(DepositStatus.PAID).withPaid(Instant.now());
+
+        Payment payment = new Payment(
+                null,
+                deposit.getCustomerId(),
+                deposit.getId(),
+                null,
+                null,
+                deposit.getAmount(),
+                PaymentType.DEPOSIT,
+                PaymentStatus.COMPLETED,
+                command.paymentMethod(),
+                null,
+                null,
+                null,
+                null,
+                null);
+        savePaymentPort.save(payment);
+
+        DepositRequest saved = saveDepositPort.save(updated);
+        eventPublisher.publishEvent(new DepositConfirmedEvent(deposit.getRoomId(), deposit.getBedId()));
+        return saved;
+    }
+
+    @Override
+    @Transactional
+    public DepositRequest cancelDeposit(UUID id) {
+        DepositRequest deposit = loadDepositPort.loadById(id)
+                .orElseThrow(() -> new NotFoundException("Deposit request not found"));
+        return saveDepositPort.save(deposit.withStatus(DepositStatus.CANCELLED));
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/MyBookingService.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/MyBookingService.java
@@ -1,0 +1,248 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import vn.edu.hcmus.homestay.application.port.in.GetMyBookingUseCase;
+import vn.edu.hcmus.homestay.application.port.out.LoadBedPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadBranchPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadDepositPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadRentalRequestPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadRoomPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveDepositPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveRentalRequestPort;
+import vn.edu.hcmus.homestay.common.exception.ConflictException;
+import vn.edu.hcmus.homestay.common.exception.ForbiddenException;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+import vn.edu.hcmus.homestay.domain.model.bed.BedStatus;
+import vn.edu.hcmus.homestay.domain.model.branch.Branch;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositStatus;
+import vn.edu.hcmus.homestay.domain.model.mybooking.MyBooking;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequestStatus;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+import vn.edu.hcmus.homestay.domain.model.room.RoomStatus;
+
+@Service
+public class MyBookingService implements GetMyBookingUseCase {
+
+    private static final Set<RentalRequestStatus> CANCELLABLE_STATUSES = Set.of(
+            RentalRequestStatus.REQUESTED,
+            RentalRequestStatus.REVIEWING,
+            RentalRequestStatus.VIEWING_SCHEDULED);
+
+    private final LoadRentalRequestPort loadRentalRequestPort;
+    private final LoadDepositPort loadDepositPort;
+    private final LoadRoomPort loadRoomPort;
+    private final LoadBedPort loadBedPort;
+    private final LoadBranchPort loadBranchPort;
+    private final SaveRentalRequestPort saveRentalRequestPort;
+    private final SaveDepositPort saveDepositPort;
+
+    public MyBookingService(
+            LoadRentalRequestPort loadRentalRequestPort,
+            LoadDepositPort loadDepositPort,
+            LoadRoomPort loadRoomPort,
+            LoadBedPort loadBedPort,
+            LoadBranchPort loadBranchPort,
+            SaveRentalRequestPort saveRentalRequestPort,
+            SaveDepositPort saveDepositPort) {
+        this.loadRentalRequestPort = loadRentalRequestPort;
+        this.loadDepositPort = loadDepositPort;
+        this.loadRoomPort = loadRoomPort;
+        this.loadBedPort = loadBedPort;
+        this.loadBranchPort = loadBranchPort;
+        this.saveRentalRequestPort = saveRentalRequestPort;
+        this.saveDepositPort = saveDepositPort;
+    }
+
+    @Override
+    public List<MyBooking> getMyBookings(UUID customerId, String statusFilter) {
+        List<RentalRequest> requests = loadRentalRequestPort.loadByCustomerId(customerId);
+
+        if (statusFilter != null && !statusFilter.isBlank()) {
+            Set<RentalRequestStatus> filterStatuses = resolveStatusFilter(statusFilter);
+            requests = requests.stream()
+                    .filter(r -> filterStatuses.contains(r.getStatus()))
+                    .toList();
+        }
+
+        return requests.stream()
+                .map(req -> assembleMyBooking(req, findDepositForRequest(req)))
+                .toList();
+    }
+
+    @Override
+    public MyBooking getMyBooking(UUID bookingId, UUID customerId) {
+        RentalRequest req = loadRentalRequestPort.loadById(bookingId)
+                .orElseThrow(() -> new NotFoundException("Booking not found"));
+
+        if (!req.getCustomerId().equals(customerId)) {
+            throw new ForbiddenException("Access denied");
+        }
+
+        return assembleMyBooking(req, findDepositForRequest(req));
+    }
+
+    @Override
+    public boolean checkAvailability(UUID bookingId, UUID customerId) {
+        RentalRequest req = loadRentalRequestPort.loadById(bookingId)
+                .orElseThrow(() -> new NotFoundException("Booking not found"));
+
+        if (!req.getCustomerId().equals(customerId)) {
+            throw new ForbiddenException("Access denied");
+        }
+
+        boolean available;
+        if (req.getBedId() != null) {
+            Optional<Bed> bed = loadBedPort.loadById(req.getBedId());
+            available = bed.map(b -> b.getStatus() == BedStatus.AVAILABLE).orElse(false);
+        } else if (req.getRoomId() != null) {
+            Optional<Room> room = loadRoomPort.loadById(req.getRoomId());
+            available = room.map(r -> r.getStatus() == RoomStatus.AVAILABLE).orElse(false);
+        } else {
+            available = false;
+        }
+
+        if (!available) {
+            RentalRequest cancelled = req.withStatus(RentalRequestStatus.CANCELLED);
+            saveRentalRequestPort.save(cancelled);
+
+            findDepositForRequest(req).ifPresent(deposit -> {
+                if (deposit.getStatus() == DepositStatus.PENDING) {
+                    saveDepositPort.save(deposit.withStatus(DepositStatus.CANCELLED));
+                }
+            });
+        }
+
+        return available;
+    }
+
+    @Override
+    public MyBooking submitProof(UUID bookingId, UUID customerId, String proofImageUrl) {
+        RentalRequest req = loadRentalRequestPort.loadById(bookingId)
+                .orElseThrow(() -> new NotFoundException("Booking not found"));
+
+        if (!req.getCustomerId().equals(customerId)) {
+            throw new ForbiddenException("Access denied");
+        }
+
+        Optional<DepositRequest> existingDeposit = findDepositForRequest(req);
+
+        DepositRequest deposit;
+        if (existingDeposit.isPresent()) {
+            deposit = existingDeposit.get().withProofImageUrl(proofImageUrl);
+        } else {
+            // Auto-create deposit when none exists
+            Room room = req.getRoomId() != null
+                    ? loadRoomPort.loadById(req.getRoomId()).orElse(null)
+                    : null;
+            java.math.BigDecimal amount = (room != null && room.getPricePerMonth() != null)
+                    ? room.getPricePerMonth().multiply(java.math.BigDecimal.TWO)
+                    : java.math.BigDecimal.ZERO;
+
+            deposit = new DepositRequest(
+                    null,
+                    req.getId(),
+                    req.getCustomerId(),
+                    req.getRoomId(),
+                    req.getBedId(),
+                    amount,
+                    Instant.now().plus(24, ChronoUnit.HOURS),
+                    null,
+                    proofImageUrl,
+                    null,
+                    null,
+                    DepositStatus.PENDING,
+                    null,
+                    null);
+        }
+
+        DepositRequest savedDeposit = saveDepositPort.save(deposit);
+        return assembleMyBooking(req, Optional.of(savedDeposit));
+    }
+
+    @Override
+    public MyBooking cancelBooking(UUID bookingId, UUID customerId) {
+        RentalRequest req = loadRentalRequestPort.loadById(bookingId)
+                .orElseThrow(() -> new NotFoundException("Booking not found"));
+
+        if (!req.getCustomerId().equals(customerId)) {
+            throw new ForbiddenException("Access denied");
+        }
+
+        if (!CANCELLABLE_STATUSES.contains(req.getStatus())) {
+            throw new ConflictException(
+                    "Cannot cancel a booking with status: " + req.getStatus().name().toLowerCase());
+        }
+
+        RentalRequest cancelled = req.withStatus(RentalRequestStatus.CANCELLED);
+        saveRentalRequestPort.save(cancelled);
+        return assembleMyBooking(cancelled, findDepositForRequest(req));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Optional<DepositRequest> findDepositForRequest(RentalRequest req) {
+        return loadDepositPort.loadAll().stream()
+                .filter(d -> req.getId().equals(d.getRentalRequestId()))
+                .findFirst();
+    }
+
+    private MyBooking assembleMyBooking(RentalRequest req, Optional<DepositRequest> depositOpt) {
+        Room room = req.getRoomId() != null
+                ? loadRoomPort.loadById(req.getRoomId()).orElse(null)
+                : null;
+
+        Bed bed = req.getBedId() != null
+                ? loadBedPort.loadById(req.getBedId()).orElse(null)
+                : null;
+
+        Branch branch = (room != null)
+                ? loadBranchPort.loadById(room.getBranchId()).orElse(null)
+                : null;
+
+        DepositRequest deposit = depositOpt.orElse(null);
+
+        return new MyBooking(
+                req.getId(),
+                req.getCustomerId(),
+                branch != null ? branch.getName() : null,
+                branch != null ? branch.getAddress() : null,
+                room != null ? room.getRoomNumber() : null,
+                room != null ? room.getRoomType() : null,
+                room != null ? room.getPricePerMonth() : null,
+                bed != null ? bed.getBedNumber() : null,
+                req.getPeopleCount(),
+                req.getNote(),
+                req.getStatus() != null ? req.getStatus().name().toLowerCase() : null,
+                deposit != null ? deposit.getId() : null,
+                deposit != null ? deposit.getAmount() : null,
+                deposit != null && deposit.getStatus() != null
+                        ? deposit.getStatus().name().toLowerCase()
+                        : null,
+                deposit != null ? deposit.getDueAt() : null,
+                deposit != null ? deposit.getVietqrReference() : null,
+                req.getCreatedAt(),
+                req.getUpdatedAt());
+    }
+
+    private Set<RentalRequestStatus> resolveStatusFilter(String filter) {
+        return switch (filter.toLowerCase()) {
+            case "pending" -> Set.of(RentalRequestStatus.REQUESTED, RentalRequestStatus.REVIEWING);
+            case "confirmed" -> Set.of(
+                    RentalRequestStatus.VIEWING_SCHEDULED, RentalRequestStatus.ACCEPTED);
+            case "deposit" -> Set.of(RentalRequestStatus.DEPOSIT_PENDING);
+            case "completed" -> Set.of(RentalRequestStatus.COMPLETED);
+            case "cancelled" -> Set.of(RentalRequestStatus.CANCELLED);
+            case "rejected" -> Set.of(RentalRequestStatus.REJECTED);
+            default -> Set.of(RentalRequestStatus.values());
+        };
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/PaymentService.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/application/service/PaymentService.java
@@ -1,0 +1,22 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import vn.edu.hcmus.homestay.application.port.in.GetPaymentUseCase;
+import vn.edu.hcmus.homestay.application.port.out.LoadPaymentPort;
+import vn.edu.hcmus.homestay.domain.model.payment.Payment;
+
+@Service
+public class PaymentService implements GetPaymentUseCase {
+
+    private final LoadPaymentPort loadPaymentPort;
+
+    public PaymentService(LoadPaymentPort loadPaymentPort) {
+        this.loadPaymentPort = loadPaymentPort;
+    }
+
+    @Override
+    public List<Payment> getAllPayments() {
+        return loadPaymentPort.loadAll();
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/common/event/DepositConfirmedEvent.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/common/event/DepositConfirmedEvent.java
@@ -1,0 +1,5 @@
+package vn.edu.hcmus.homestay.common.event;
+
+import java.util.UUID;
+
+public record DepositConfirmedEvent(UUID roomId, UUID bedId) {}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/common/event/DepositExpiredEvent.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/common/event/DepositExpiredEvent.java
@@ -1,0 +1,5 @@
+package vn.edu.hcmus.homestay.common.event;
+
+import java.util.UUID;
+
+public record DepositExpiredEvent(UUID roomId, UUID bedId) {}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/config/SchedulingConfig.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/config/SchedulingConfig.java
@@ -1,0 +1,8 @@
+package vn.edu.hcmus.homestay.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/deposit/DepositRequest.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/deposit/DepositRequest.java
@@ -1,0 +1,143 @@
+package vn.edu.hcmus.homestay.domain.model.deposit;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/** Pure domain entity — no JPA annotations, no Spring dependencies. */
+public class DepositRequest {
+
+    private final UUID id;
+    private final UUID rentalRequestId;
+    private final UUID customerId;
+    private final UUID roomId;
+    private final UUID bedId;
+    private final BigDecimal amount;
+    private final Instant dueAt;
+    private final Instant paidAt;
+    private final String proofImageUrl;
+    private final String vietqrReference;
+    private final String notes;
+    private final DepositStatus status;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public DepositRequest(
+            UUID id,
+            UUID rentalRequestId,
+            UUID customerId,
+            UUID roomId,
+            UUID bedId,
+            BigDecimal amount,
+            Instant dueAt,
+            Instant paidAt,
+            String proofImageUrl,
+            String vietqrReference,
+            String notes,
+            DepositStatus status,
+            Instant createdAt,
+            Instant updatedAt) {
+        this.id = id;
+        this.rentalRequestId = rentalRequestId;
+        this.customerId = customerId;
+        this.roomId = roomId;
+        this.bedId = bedId;
+        this.amount = amount;
+        this.dueAt = dueAt;
+        this.paidAt = paidAt;
+        this.proofImageUrl = proofImageUrl;
+        this.vietqrReference = vietqrReference;
+        this.notes = notes;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getRentalRequestId() {
+        return rentalRequestId;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public UUID getBedId() {
+        return bedId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public Instant getDueAt() {
+        return dueAt;
+    }
+
+    public Instant getPaidAt() {
+        return paidAt;
+    }
+
+    public String getProofImageUrl() {
+        return proofImageUrl;
+    }
+
+    public String getVietqrReference() {
+        return vietqrReference;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public DepositStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    /** Returns a copy of this deposit with a new status. */
+    public DepositRequest withStatus(DepositStatus newStatus) {
+        return new DepositRequest(
+                id, rentalRequestId, customerId, roomId, bedId,
+                amount, dueAt, paidAt, proofImageUrl, vietqrReference,
+                notes, newStatus, createdAt, updatedAt);
+    }
+
+    /** Returns a copy of this deposit with paidAt set. */
+    public DepositRequest withPaid(Instant newPaidAt) {
+        return new DepositRequest(
+                id, rentalRequestId, customerId, roomId, bedId,
+                amount, dueAt, newPaidAt, proofImageUrl, vietqrReference,
+                notes, status, createdAt, updatedAt);
+    }
+
+    /** Returns a copy of this deposit with proofImageUrl set. */
+    public DepositRequest withProofImageUrl(String newProofImageUrl) {
+        return new DepositRequest(
+                id, rentalRequestId, customerId, roomId, bedId,
+                amount, dueAt, paidAt, newProofImageUrl, vietqrReference,
+                notes, status, createdAt, updatedAt);
+    }
+
+    /** Returns a copy of this deposit with vietqrReference set. */
+    public DepositRequest withVietQRReference(String newVietqrReference) {
+        return new DepositRequest(
+                id, rentalRequestId, customerId, roomId, bedId,
+                amount, dueAt, paidAt, proofImageUrl, newVietqrReference,
+                notes, status, createdAt, updatedAt);
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/deposit/DepositStatus.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/deposit/DepositStatus.java
@@ -1,0 +1,5 @@
+package vn.edu.hcmus.homestay.domain.model.deposit;
+
+public enum DepositStatus {
+    PENDING, PAID, CANCELLED, EXPIRED, REFUNDED
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/mybooking/MyBooking.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/mybooking/MyBooking.java
@@ -1,0 +1,139 @@
+package vn.edu.hcmus.homestay.domain.model.mybooking;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/** Read-only aggregate view of a customer's booking — not a DB table. */
+public class MyBooking {
+
+    private final UUID id;
+    private final UUID customerId;
+    private final String branchName;
+    private final String branchAddress;
+    private final String roomNumber;
+    private final String roomType;
+    private final BigDecimal pricePerMonth;
+    private final String bedNumber;
+    private final int peopleCount;
+    private final String note;
+    private final String status;
+    private final UUID depositId;
+    private final BigDecimal depositAmount;
+    private final String depositStatus;
+    private final Instant depositDueAt;
+    private final String vietqrReference;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public MyBooking(
+            UUID id,
+            UUID customerId,
+            String branchName,
+            String branchAddress,
+            String roomNumber,
+            String roomType,
+            BigDecimal pricePerMonth,
+            String bedNumber,
+            int peopleCount,
+            String note,
+            String status,
+            UUID depositId,
+            BigDecimal depositAmount,
+            String depositStatus,
+            Instant depositDueAt,
+            String vietqrReference,
+            Instant createdAt,
+            Instant updatedAt) {
+        this.id = id;
+        this.customerId = customerId;
+        this.branchName = branchName;
+        this.branchAddress = branchAddress;
+        this.roomNumber = roomNumber;
+        this.roomType = roomType;
+        this.pricePerMonth = pricePerMonth;
+        this.bedNumber = bedNumber;
+        this.peopleCount = peopleCount;
+        this.note = note;
+        this.status = status;
+        this.depositId = depositId;
+        this.depositAmount = depositAmount;
+        this.depositStatus = depositStatus;
+        this.depositDueAt = depositDueAt;
+        this.vietqrReference = vietqrReference;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public String getBranchName() {
+        return branchName;
+    }
+
+    public String getBranchAddress() {
+        return branchAddress;
+    }
+
+    public String getRoomNumber() {
+        return roomNumber;
+    }
+
+    public String getRoomType() {
+        return roomType;
+    }
+
+    public BigDecimal getPricePerMonth() {
+        return pricePerMonth;
+    }
+
+    public String getBedNumber() {
+        return bedNumber;
+    }
+
+    public int getPeopleCount() {
+        return peopleCount;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public UUID getDepositId() {
+        return depositId;
+    }
+
+    public BigDecimal getDepositAmount() {
+        return depositAmount;
+    }
+
+    public String getDepositStatus() {
+        return depositStatus;
+    }
+
+    public Instant getDepositDueAt() {
+        return depositDueAt;
+    }
+
+    public String getVietqrReference() {
+        return vietqrReference;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/payment/Payment.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/payment/Payment.java
@@ -1,0 +1,111 @@
+package vn.edu.hcmus.homestay.domain.model.payment;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/** Pure domain entity — no JPA annotations, no Spring dependencies. */
+public class Payment {
+
+    private final UUID id;
+    private final UUID userId;
+    private final UUID depositRequestId;
+    private final UUID contractId;
+    private final UUID settlementId;
+    private final BigDecimal amount;
+    private final PaymentType type;
+    private final PaymentStatus status;
+    private final PaymentMethod paymentMethod;
+    private final String vietqrReference;
+    private final String proofImageUrl;
+    private final String notes;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public Payment(
+            UUID id,
+            UUID userId,
+            UUID depositRequestId,
+            UUID contractId,
+            UUID settlementId,
+            BigDecimal amount,
+            PaymentType type,
+            PaymentStatus status,
+            PaymentMethod paymentMethod,
+            String vietqrReference,
+            String proofImageUrl,
+            String notes,
+            Instant createdAt,
+            Instant updatedAt) {
+        this.id = id;
+        this.userId = userId;
+        this.depositRequestId = depositRequestId;
+        this.contractId = contractId;
+        this.settlementId = settlementId;
+        this.amount = amount;
+        this.type = type;
+        this.status = status;
+        this.paymentMethod = paymentMethod;
+        this.vietqrReference = vietqrReference;
+        this.proofImageUrl = proofImageUrl;
+        this.notes = notes;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public UUID getDepositRequestId() {
+        return depositRequestId;
+    }
+
+    public UUID getContractId() {
+        return contractId;
+    }
+
+    public UUID getSettlementId() {
+        return settlementId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public PaymentType getType() {
+        return type;
+    }
+
+    public PaymentStatus getStatus() {
+        return status;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public String getVietqrReference() {
+        return vietqrReference;
+    }
+
+    public String getProofImageUrl() {
+        return proofImageUrl;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/payment/PaymentMethod.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/payment/PaymentMethod.java
@@ -1,0 +1,5 @@
+package vn.edu.hcmus.homestay.domain.model.payment;
+
+public enum PaymentMethod {
+    CASH, TRANSFER, VIETQR
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/payment/PaymentStatus.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/payment/PaymentStatus.java
@@ -1,0 +1,5 @@
+package vn.edu.hcmus.homestay.domain.model.payment;
+
+public enum PaymentStatus {
+    PENDING, COMPLETED, FAILED, REFUNDED
+}

--- a/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/payment/PaymentType.java
+++ b/backend-spring/src/main/java/vn/edu/hcmus/homestay/domain/model/payment/PaymentType.java
@@ -1,0 +1,5 @@
+package vn.edu.hcmus.homestay.domain.model.payment;
+
+public enum PaymentType {
+    RENT, DEPOSIT, REFUND, FEE
+}

--- a/backend-spring/src/main/resources/application.properties
+++ b/backend-spring/src/main/resources/application.properties
@@ -26,3 +26,11 @@ spring.jackson.default-property-inclusion=non_null
 # Throw NoHandlerFoundException on unmapped routes so GlobalExceptionHandler formats it.
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.web.resources.add-mappings=false
+
+# VietQR payment integration
+vietqr.client-id=${VIETQR_CLIENT_ID:}
+vietqr.client-secret=${VIETQR_CLIENT_SECRET:}
+vietqr.bank-bin=${VIETQR_BANK_BIN:970422}
+vietqr.account-no=${VIETQR_ACCOUNT_NO:}
+vietqr.account-name=${VIETQR_ACCOUNT_NAME:}
+vietqr.template=${VIETQR_TEMPLATE:compact}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/scheduler/DepositExpirySchedulerTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/scheduler/DepositExpirySchedulerTest.java
@@ -1,0 +1,98 @@
+package vn.edu.hcmus.homestay.adapter.in.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import vn.edu.hcmus.homestay.application.port.out.LoadDepositPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveDepositPort;
+import vn.edu.hcmus.homestay.common.event.DepositExpiredEvent;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositStatus;
+
+@ExtendWith(MockitoExtension.class)
+class DepositExpirySchedulerTest {
+
+    @Mock
+    private LoadDepositPort loadDepositPort;
+
+    @Mock
+    private SaveDepositPort saveDepositPort;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private DepositExpiryScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new DepositExpiryScheduler(loadDepositPort, saveDepositPort, eventPublisher);
+    }
+
+    @Test
+    void expireOverdueDeposits_noOverdue_doesNothing() {
+        when(loadDepositPort.loadPendingExpired(any(Instant.class))).thenReturn(List.of());
+
+        scheduler.expireOverdueDeposits();
+
+        verify(saveDepositPort, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void expireOverdueDeposits_withOverdue_setsExpiredAndPublishesEvent() {
+        UUID roomId1 = UUID.randomUUID();
+        UUID roomId2 = UUID.randomUUID();
+        DepositRequest deposit1 = overdueDeposit(UUID.randomUUID(), roomId1, null);
+        DepositRequest deposit2 = overdueDeposit(UUID.randomUUID(), roomId2, UUID.randomUUID());
+
+        when(loadDepositPort.loadPendingExpired(any(Instant.class)))
+                .thenReturn(List.of(deposit1, deposit2));
+        when(saveDepositPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        scheduler.expireOverdueDeposits();
+
+        verify(saveDepositPort, times(2)).save(any());
+
+        ArgumentCaptor<DepositRequest> savedCaptor = ArgumentCaptor.forClass(DepositRequest.class);
+        verify(saveDepositPort, times(2)).save(savedCaptor.capture());
+        savedCaptor.getAllValues().forEach(d ->
+                org.assertj.core.api.Assertions.assertThat(d.getStatus())
+                        .isEqualTo(DepositStatus.EXPIRED));
+
+        verify(eventPublisher, times(2)).publishEvent(any(DepositExpiredEvent.class));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private DepositRequest overdueDeposit(UUID id, UUID roomId, UUID bedId) {
+        return new DepositRequest(
+                id,
+                null,
+                UUID.randomUUID(),
+                roomId,
+                bedId,
+                BigDecimal.valueOf(3000000),
+                Instant.now().minusSeconds(3600),
+                null,
+                null,
+                null,
+                null,
+                DepositStatus.PENDING,
+                Instant.now().minusSeconds(86400),
+                Instant.now().minusSeconds(86400));
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/DepositControllerTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/DepositControllerTest.java
@@ -1,0 +1,212 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import vn.edu.hcmus.homestay.adapter.in.security.UserPrincipal;
+import vn.edu.hcmus.homestay.adapter.out.security.JwtTokenProvider;
+import vn.edu.hcmus.homestay.application.port.in.CancelDepositUseCase;
+import vn.edu.hcmus.homestay.application.port.in.ConfirmDepositUseCase;
+import vn.edu.hcmus.homestay.application.port.in.CreateDepositUseCase;
+import vn.edu.hcmus.homestay.application.port.in.GetDepositUseCase;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.config.SecurityConfig;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositStatus;
+import vn.edu.hcmus.homestay.domain.model.user.AppRole;
+
+@WebMvcTest(DepositController.class)
+@Import(SecurityConfig.class)
+class DepositControllerTest {
+
+    private static final String SECRET = "change-me-to-a-real-secret-at-least-32-chars";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CreateDepositUseCase createDepositUseCase;
+
+    @MockitoBean
+    private GetDepositUseCase getDepositUseCase;
+
+    @MockitoBean
+    private ConfirmDepositUseCase confirmDepositUseCase;
+
+    @MockitoBean
+    private CancelDepositUseCase cancelDepositUseCase;
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void getAllDeposits_unauthenticated_401() throws Exception {
+        mockMvc.perform(get("/api/deposits"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getAllDeposits_asCustomer_403() throws Exception {
+        UserPrincipal principal = new UserPrincipal(UUID.randomUUID(), "customer@example.com", AppRole.CUSTOMER);
+
+        mockMvc.perform(get("/api/deposits")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        principal, null, principal.getAuthorities()))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getAllDeposits_asStaff_200() throws Exception {
+        UserPrincipal principal = new UserPrincipal(UUID.randomUUID(), "sale@example.com", AppRole.SALE);
+        when(getDepositUseCase.getAllDeposits()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/deposits")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void getDeposit_asStaff_200() throws Exception {
+        UUID depositId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(UUID.randomUUID(), "sale@example.com", AppRole.SALE);
+        when(getDepositUseCase.getDeposit(depositId)).thenReturn(deposit(depositId));
+
+        mockMvc.perform(get("/api/deposits/{id}", depositId)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(depositId.toString()));
+    }
+
+    @Test
+    void getDeposit_notFound_404() throws Exception {
+        UUID depositId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(UUID.randomUUID(), "sale@example.com", AppRole.SALE);
+        when(getDepositUseCase.getDeposit(depositId))
+                .thenThrow(new NotFoundException("Deposit request not found"));
+
+        mockMvc.perform(get("/api/deposits/{id}", depositId)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        principal, null, principal.getAuthorities()))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void createDeposit_asStaff_201() throws Exception {
+        UUID depositId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(UUID.randomUUID(), "sale@example.com", AppRole.SALE);
+        when(createDepositUseCase.createDeposit(any())).thenReturn(deposit(depositId));
+
+        mockMvc.perform(post("/api/deposits")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "room_id": "%s",
+                                  "amount": 5000000,
+                                  "payment_method": "CASH"
+                                }
+                                """.formatted(UUID.randomUUID()))
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        principal, null, principal.getAuthorities()))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void createDeposit_unauthenticated_401() throws Exception {
+        mockMvc.perform(post("/api/deposits")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"room_id\":\"" + UUID.randomUUID() + "\",\"amount\":5000000,\"payment_method\":\"CASH\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void confirmDeposit_asStaff_200() throws Exception {
+        UUID depositId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(UUID.randomUUID(), "accountant@example.com", AppRole.ACCOUNTANT);
+        when(confirmDepositUseCase.confirmDeposit(eq(depositId), any()))
+                .thenReturn(deposit(depositId));
+
+        mockMvc.perform(patch("/api/deposits/{id}/confirm", depositId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"payment_method\":\"CASH\"}")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void cancelDeposit_asStaff_200() throws Exception {
+        UUID depositId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(UUID.randomUUID(), "sale@example.com", AppRole.SALE);
+        when(cancelDepositUseCase.cancelDeposit(depositId)).thenReturn(deposit(depositId));
+
+        mockMvc.perform(patch("/api/deposits/{id}/cancel", depositId)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private DepositRequest deposit(UUID id) {
+        return new DepositRequest(
+                id,
+                null,
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                BigDecimal.valueOf(5000000),
+                Instant.now().plusSeconds(86400),
+                null,
+                null,
+                null,
+                null,
+                DepositStatus.PENDING,
+                Instant.now(),
+                Instant.now());
+    }
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Primary
+        @Bean
+        public JwtTokenProvider jwtTokenProvider() {
+            return new JwtTokenProvider(SECRET);
+        }
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/MyBookingControllerTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/adapter/in/web/MyBookingControllerTest.java
@@ -1,0 +1,142 @@
+package vn.edu.hcmus.homestay.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import vn.edu.hcmus.homestay.adapter.in.security.UserPrincipal;
+import vn.edu.hcmus.homestay.adapter.out.security.JwtTokenProvider;
+import vn.edu.hcmus.homestay.application.port.in.GetMyBookingUseCase;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.config.SecurityConfig;
+import vn.edu.hcmus.homestay.domain.model.mybooking.MyBooking;
+import vn.edu.hcmus.homestay.domain.model.user.AppRole;
+
+@WebMvcTest(MyBookingController.class)
+@Import(SecurityConfig.class)
+class MyBookingControllerTest {
+
+    private static final String SECRET = "change-me-to-a-real-secret-at-least-32-chars";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GetMyBookingUseCase getMyBookingUseCase;
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void getMyBookings_unauthenticated_401() throws Exception {
+        mockMvc.perform(get("/api/my-booking"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getMyBookings_authenticated_200() throws Exception {
+        UUID customerId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(customerId, "customer@example.com", AppRole.CUSTOMER);
+        when(getMyBookingUseCase.getMyBookings(eq(customerId), any())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/my-booking")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void getMyBooking_notFound_404() throws Exception {
+        UUID customerId = UUID.randomUUID();
+        UUID bookingId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(customerId, "customer@example.com", AppRole.CUSTOMER);
+        when(getMyBookingUseCase.getMyBooking(eq(bookingId), eq(customerId)))
+                .thenThrow(new NotFoundException("Booking not found"));
+
+        mockMvc.perform(get("/api/my-booking/{id}", bookingId)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        principal, null, principal.getAuthorities()))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void checkAvailability_authenticated_200() throws Exception {
+        UUID customerId = UUID.randomUUID();
+        UUID bookingId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(customerId, "customer@example.com", AppRole.CUSTOMER);
+        when(getMyBookingUseCase.checkAvailability(eq(bookingId), eq(customerId))).thenReturn(true);
+
+        mockMvc.perform(get("/api/my-booking/{id}/check-availability", bookingId)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.isAvailable").value(true));
+    }
+
+    @Test
+    void cancelBooking_authenticated_200() throws Exception {
+        UUID customerId = UUID.randomUUID();
+        UUID bookingId = UUID.randomUUID();
+        UserPrincipal principal = new UserPrincipal(customerId, "customer@example.com", AppRole.CUSTOMER);
+        when(getMyBookingUseCase.cancelBooking(eq(bookingId), eq(customerId)))
+                .thenReturn(myBooking(bookingId, customerId));
+
+        mockMvc.perform(post("/api/my-booking/{id}/cancel", bookingId)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        principal, null, principal.getAuthorities()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void submitProof_unauthenticated_401() throws Exception {
+        mockMvc.perform(post("/api/my-booking/{id}/submit-proof", UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"proof_image_url\":\"https://example.com/proof.jpg\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private MyBooking myBooking(UUID id, UUID customerId) {
+        return new MyBooking(
+                id, customerId, null, null, null, null, null, null,
+                1, null, "cancelled", null, null, null, null, null,
+                Instant.now(), Instant.now());
+    }
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Primary
+        @Bean
+        public JwtTokenProvider jwtTokenProvider() {
+            return new JwtTokenProvider(SECRET);
+        }
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/DepositServiceTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/DepositServiceTest.java
@@ -1,0 +1,177 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import vn.edu.hcmus.homestay.application.port.in.ConfirmDepositUseCase.ConfirmDepositCommand;
+import vn.edu.hcmus.homestay.application.port.in.CreateDepositUseCase.CreateDepositCommand;
+import vn.edu.hcmus.homestay.application.port.out.GenerateVietQRPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadDepositPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveDepositPort;
+import vn.edu.hcmus.homestay.application.port.out.SavePaymentPort;
+import vn.edu.hcmus.homestay.common.event.DepositConfirmedEvent;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositStatus;
+import vn.edu.hcmus.homestay.domain.model.payment.Payment;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentMethod;
+import vn.edu.hcmus.homestay.domain.model.payment.PaymentStatus;
+
+@ExtendWith(MockitoExtension.class)
+class DepositServiceTest {
+
+    @Mock
+    private LoadDepositPort loadDepositPort;
+
+    @Mock
+    private SaveDepositPort saveDepositPort;
+
+    @Mock
+    private SavePaymentPort savePaymentPort;
+
+    @Mock
+    private GenerateVietQRPort generateVietQRPort;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private DepositService depositService;
+
+    @BeforeEach
+    void setUp() {
+        depositService = new DepositService(
+                loadDepositPort, saveDepositPort, savePaymentPort, generateVietQRPort, eventPublisher);
+    }
+
+    @Test
+    void createDeposit_cash_doesNotCallVietQR() {
+        UUID roomId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        CreateDepositCommand command = new CreateDepositCommand(
+                null, customerId, roomId, null, BigDecimal.valueOf(5000000), PaymentMethod.CASH, null);
+        when(saveDepositPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        depositService.createDeposit(command);
+
+        verify(generateVietQRPort, never()).generateQRUrl(any(), any());
+    }
+
+    @Test
+    void createDeposit_vietqr_populatesReference() {
+        UUID roomId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        String qrUrl = "data:image/png;base64,abc123";
+        CreateDepositCommand command = new CreateDepositCommand(
+                null, customerId, roomId, null, BigDecimal.valueOf(5000000), PaymentMethod.VIETQR, null);
+        when(generateVietQRPort.generateQRUrl(any(), any())).thenReturn(qrUrl);
+        when(saveDepositPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        DepositRequest result = depositService.createDeposit(command);
+
+        verify(generateVietQRPort).generateQRUrl(eq(BigDecimal.valueOf(5000000)), any());
+        assertThat(result.getVietqrReference()).isEqualTo(qrUrl);
+    }
+
+    @Test
+    void createDeposit_vietqrApiFails_savesWithNullReference() {
+        UUID roomId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        CreateDepositCommand command = new CreateDepositCommand(
+                null, customerId, roomId, null, BigDecimal.valueOf(5000000), PaymentMethod.VIETQR, null);
+        when(generateVietQRPort.generateQRUrl(any(), any())).thenReturn(null);
+        when(saveDepositPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        DepositRequest result = depositService.createDeposit(command);
+
+        assertThat(result.getVietqrReference()).isNull();
+    }
+
+    @Test
+    void confirmDeposit_setsStatusPaid_createsPayment_publishesEvent() {
+        UUID depositId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID roomId = UUID.randomUUID();
+        DepositRequest existing = depositRequest(depositId, customerId, roomId, DepositStatus.PENDING);
+
+        when(loadDepositPort.loadById(depositId)).thenReturn(Optional.of(existing));
+        when(saveDepositPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(savePaymentPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        DepositRequest result = depositService.confirmDeposit(
+                depositId, new ConfirmDepositCommand(PaymentMethod.CASH));
+
+        assertThat(result.getStatus()).isEqualTo(DepositStatus.PAID);
+        assertThat(result.getPaidAt()).isNotNull();
+
+        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+        verify(savePaymentPort).save(paymentCaptor.capture());
+        Payment savedPayment = paymentCaptor.getValue();
+        assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+        assertThat(savedPayment.getDepositRequestId()).isEqualTo(depositId);
+
+        ArgumentCaptor<DepositConfirmedEvent> eventCaptor =
+                ArgumentCaptor.forClass(DepositConfirmedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().roomId()).isEqualTo(roomId);
+    }
+
+    @Test
+    void confirmDeposit_notFound_throwsNotFoundException() {
+        UUID depositId = UUID.randomUUID();
+        when(loadDepositPort.loadById(depositId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> depositService.confirmDeposit(
+                        depositId, new ConfirmDepositCommand(PaymentMethod.CASH)))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void cancelDeposit_setsCancelled() {
+        UUID depositId = UUID.randomUUID();
+        DepositRequest existing = depositRequest(
+                depositId, UUID.randomUUID(), UUID.randomUUID(), DepositStatus.PENDING);
+
+        when(loadDepositPort.loadById(depositId)).thenReturn(Optional.of(existing));
+        when(saveDepositPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        DepositRequest result = depositService.cancelDeposit(depositId);
+
+        assertThat(result.getStatus()).isEqualTo(DepositStatus.CANCELLED);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private DepositRequest depositRequest(UUID id, UUID customerId, UUID roomId, DepositStatus status) {
+        return new DepositRequest(
+                id,
+                null,
+                customerId,
+                roomId,
+                null,
+                BigDecimal.valueOf(5000000),
+                Instant.now().plusSeconds(86400),
+                null,
+                null,
+                null,
+                null,
+                status,
+                Instant.now(),
+                Instant.now());
+    }
+}

--- a/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/MyBookingServiceTest.java
+++ b/backend-spring/src/test/java/vn/edu/hcmus/homestay/application/service/MyBookingServiceTest.java
@@ -1,0 +1,226 @@
+package vn.edu.hcmus.homestay.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import vn.edu.hcmus.homestay.application.port.out.LoadBedPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadBranchPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadDepositPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadRentalRequestPort;
+import vn.edu.hcmus.homestay.application.port.out.LoadRoomPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveDepositPort;
+import vn.edu.hcmus.homestay.application.port.out.SaveRentalRequestPort;
+import vn.edu.hcmus.homestay.common.exception.ConflictException;
+import vn.edu.hcmus.homestay.common.exception.ForbiddenException;
+import vn.edu.hcmus.homestay.common.exception.NotFoundException;
+import vn.edu.hcmus.homestay.domain.model.bed.Bed;
+import vn.edu.hcmus.homestay.domain.model.bed.BedStatus;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositRequest;
+import vn.edu.hcmus.homestay.domain.model.deposit.DepositStatus;
+import vn.edu.hcmus.homestay.domain.model.mybooking.MyBooking;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequest;
+import vn.edu.hcmus.homestay.domain.model.rental.RentalRequestStatus;
+import vn.edu.hcmus.homestay.domain.model.room.Room;
+import vn.edu.hcmus.homestay.domain.model.room.RoomStatus;
+
+@ExtendWith(MockitoExtension.class)
+class MyBookingServiceTest {
+
+    @Mock
+    private LoadRentalRequestPort loadRentalRequestPort;
+
+    @Mock
+    private LoadDepositPort loadDepositPort;
+
+    @Mock
+    private LoadRoomPort loadRoomPort;
+
+    @Mock
+    private LoadBedPort loadBedPort;
+
+    @Mock
+    private LoadBranchPort loadBranchPort;
+
+    @Mock
+    private SaveRentalRequestPort saveRentalRequestPort;
+
+    @Mock
+    private SaveDepositPort saveDepositPort;
+
+    private MyBookingService myBookingService;
+
+    @BeforeEach
+    void setUp() {
+        myBookingService = new MyBookingService(
+                loadRentalRequestPort,
+                loadDepositPort,
+                loadRoomPort,
+                loadBedPort,
+                loadBranchPort,
+                saveRentalRequestPort,
+                saveDepositPort);
+    }
+
+    @Test
+    void getMyBooking_owner_assemblesCorrectly() {
+        UUID customerId = UUID.randomUUID();
+        UUID bookingId = UUID.randomUUID();
+        // roomId=null so loadRoomPort is never called — no stub needed
+        RentalRequest req = rentalRequest(bookingId, customerId, RentalRequestStatus.REQUESTED, null, null);
+
+        when(loadRentalRequestPort.loadById(bookingId)).thenReturn(Optional.of(req));
+        when(loadDepositPort.loadAll()).thenReturn(List.of());
+
+        MyBooking booking = myBookingService.getMyBooking(bookingId, customerId);
+
+        assertThat(booking.getId()).isEqualTo(bookingId);
+        assertThat(booking.getCustomerId()).isEqualTo(customerId);
+        assertThat(booking.getStatus()).isEqualTo("requested");
+    }
+
+    @Test
+    void getMyBooking_notOwner_throwsForbidden() {
+        UUID customerId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID();
+        UUID bookingId = UUID.randomUUID();
+        RentalRequest req = rentalRequest(bookingId, customerId, RentalRequestStatus.REQUESTED, null, null);
+
+        when(loadRentalRequestPort.loadById(bookingId)).thenReturn(Optional.of(req));
+
+        assertThatThrownBy(() -> myBookingService.getMyBooking(bookingId, otherUserId))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void checkAvailability_roomAvailable_returnsTrue() {
+        UUID customerId = UUID.randomUUID();
+        UUID bookingId = UUID.randomUUID();
+        UUID roomId = UUID.randomUUID();
+        RentalRequest req = rentalRequest(bookingId, customerId, RentalRequestStatus.REQUESTED, roomId, null);
+        Room room = room(roomId, RoomStatus.AVAILABLE);
+
+        when(loadRentalRequestPort.loadById(bookingId)).thenReturn(Optional.of(req));
+        when(loadRoomPort.loadById(roomId)).thenReturn(Optional.of(room));
+
+        boolean result = myBookingService.checkAvailability(bookingId, customerId);
+
+        assertThat(result).isTrue();
+        verify(saveRentalRequestPort, never()).save(any());
+    }
+
+    @Test
+    void checkAvailability_roomNotAvailable_rejectsAndCancelsDeposit() {
+        UUID customerId = UUID.randomUUID();
+        UUID bookingId = UUID.randomUUID();
+        UUID roomId = UUID.randomUUID();
+        UUID depositId = UUID.randomUUID();
+        RentalRequest req = rentalRequest(bookingId, customerId, RentalRequestStatus.REQUESTED, roomId, null);
+        Room room = room(roomId, RoomStatus.OCCUPIED);
+        DepositRequest deposit = deposit(depositId, bookingId, DepositStatus.PENDING);
+
+        when(loadRentalRequestPort.loadById(bookingId)).thenReturn(Optional.of(req));
+        when(loadRoomPort.loadById(roomId)).thenReturn(Optional.of(room));
+        when(loadDepositPort.loadAll()).thenReturn(List.of(deposit));
+        when(saveRentalRequestPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(saveDepositPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        boolean result = myBookingService.checkAvailability(bookingId, customerId);
+
+        assertThat(result).isFalse();
+        verify(saveRentalRequestPort).save(any());
+        verify(saveDepositPort).save(any());
+    }
+
+    @Test
+    void cancelBooking_fromAllowedState_cancels() {
+        UUID customerId = UUID.randomUUID();
+        UUID bookingId = UUID.randomUUID();
+        // roomId=null so loadRoomPort is never called
+        RentalRequest req = rentalRequest(bookingId, customerId, RentalRequestStatus.REQUESTED, null, null);
+
+        when(loadRentalRequestPort.loadById(bookingId)).thenReturn(Optional.of(req));
+        when(saveRentalRequestPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(loadDepositPort.loadAll()).thenReturn(List.of());
+
+        MyBooking result = myBookingService.cancelBooking(bookingId, customerId);
+
+        assertThat(result.getStatus()).isEqualTo("cancelled");
+        verify(saveRentalRequestPort).save(any());
+    }
+
+    @Test
+    void cancelBooking_fromDisallowedState_throwsConflict() {
+        UUID customerId = UUID.randomUUID();
+        UUID bookingId = UUID.randomUUID();
+        RentalRequest req = rentalRequest(bookingId, customerId, RentalRequestStatus.COMPLETED, null, null);
+
+        when(loadRentalRequestPort.loadById(bookingId)).thenReturn(Optional.of(req));
+
+        assertThatThrownBy(() -> myBookingService.cancelBooking(bookingId, customerId))
+                .isInstanceOf(ConflictException.class);
+
+        verify(saveRentalRequestPort, never()).save(any());
+    }
+
+    @Test
+    void submitProof_existingDeposit_updatesProofUrl() {
+        UUID customerId = UUID.randomUUID();
+        UUID bookingId = UUID.randomUUID();
+        UUID depositId = UUID.randomUUID();
+        String proofUrl = "https://cdn.example.com/proof.jpg";
+        // roomId=null so loadRoomPort is never called
+        RentalRequest req = rentalRequest(bookingId, customerId, RentalRequestStatus.DEPOSIT_PENDING, null, null);
+        DepositRequest existingDeposit = deposit(depositId, bookingId, DepositStatus.PENDING);
+
+        when(loadRentalRequestPort.loadById(bookingId)).thenReturn(Optional.of(req));
+        when(loadDepositPort.loadAll()).thenReturn(List.of(existingDeposit));
+        when(saveDepositPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        MyBooking result = myBookingService.submitProof(bookingId, customerId, proofUrl);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getDepositId()).isEqualTo(depositId);
+        verify(saveDepositPort).save(any());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private RentalRequest rentalRequest(
+            UUID id, UUID customerId, RentalRequestStatus status, UUID roomId, UUID bedId) {
+        return new RentalRequest(
+                id, customerId, null, roomId, bedId, null, null, null,
+                1, null, status, Instant.now(), Instant.now());
+    }
+
+    private Room room(UUID id, RoomStatus status) {
+        return new Room(id, UUID.randomUUID(), "101", "SINGLE", 2,
+                BigDecimal.valueOf(2000000), List.of(), List.of(), status,
+                Instant.now(), Instant.now());
+    }
+
+    private Bed bed(UUID id, BedStatus status) {
+        return new Bed(id, UUID.randomUUID(), "A1", BigDecimal.valueOf(1000000),
+                status, Instant.now(), Instant.now());
+    }
+
+    private DepositRequest deposit(UUID id, UUID rentalRequestId, DepositStatus status) {
+        return new DepositRequest(
+                id, rentalRequestId, UUID.randomUUID(), UUID.randomUUID(), null,
+                BigDecimal.valueOf(4000000), Instant.now().plusSeconds(86400),
+                null, null, null, null, status, Instant.now(), Instant.now());
+    }
+}


### PR DESCRIPTION

## Summary

Ports UC2 deposit & payment flow from Express to Spring Boot: deposit creation with optional VietQR QR code generation, staff confirmation flow, customer my-booking view, and the hourly deposit-expiry scheduler. Includes first implementation of VietQR integration (credentials were configured but never wired in Express).

Closes #80

## Related References

- Issue: #80
- Epic: #72 (Spring Boot migration)
- Task doc: `docs/tasks/06-01-backend-spring-boot-migration.md` (Phase 5)
- UC: `docs/UC/UC2.md` — UC2-1, UC2-2, UC2-3

## What Changed

- [x] Backend — Spring Boot: deposit, payment, my-booking domain slices + VietQR adapter + scheduler
- [ ] Frontend — no changes
- [ ] Database / Supabase — no new migration (tables exist in `001_initial_schema.sql`)
- [x] Tests — 29 new tests across 5 test files
- [ ] Documentation — migration task doc to be updated on merge

## Implementation Notes

**VietQR:** `GenerateVietQRPort` + `VietQRAdapter` calls `api.vietqr.io/v2/generate`. Uses existing `.env` credentials (`VIETQR_BANK_ID=MBBANK`, `VIETQR_ACCOUNT_NO`, etc.). Graceful degradation — API failure logs exception class (not `getMessage()` to avoid leaking HTTP response body) and saves deposit with `vietqr_reference = null`.

**Spring events:** Deposit domain publishes `DepositConfirmedEvent` / `DepositExpiredEvent`; `CatalogEventHandler` in application layer updates room/bed status. `@EventListener` (same transaction) for atomicity.

**`@Transactional`** on `createDeposit`, `confirmDeposit`, `cancelDeposit`, and `expireOverdueDeposits` — ensures payment + deposit saves are atomic.

**`POST /api/my-booking/:id/actions` renamed to `POST /api/my-booking/:id/cancel`** — Express only supports `cancel` action; generic name was misleading.

**`checkAvailability` has side effects** — auto-rejects rental request and cancels pending deposit when room/bed is unavailable (matching Express behavior).

## Verification

```bash
cd backend-spring
./gradlew clean build   # lint + compile + 29 new tests + all prior tests green
```

## Checklist

- [x] I tested the changed behavior locally
- [x] I updated docs if behavior, routes, schema, or setup changed
- [x] I did not leave stale route, model, or enum names behind
- [x] I kept issue/task/docs naming consistent with the current source of truth
- [x] I added or updated tests where the change has meaningful risk

## Breaking Changes

None. All new endpoints; no existing routes modified.

## Follow-Up Work

- Phase 6: contracts, lodging-eligibility, handover (UC3)
- Cloudinary integration for `submit-proof` image upload (Phase 9)
- Email notifications on deposit events (Phase 9 — Resend)
