### PR TITLE
fix(fe)[#110]: implement global HTTP error interceptor with toast notifications

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -3,12 +3,13 @@ import { RouterOutlet } from '@angular/router';
 import { catchError, of } from 'rxjs';
 import { AuthService } from '@core/services/auth.service';
 import { LanguageService } from '@core/i18n/language.service';
+import { ToastComponent } from '@shared/components/toast/toast.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
-  template: '<router-outlet></router-outlet>',
+  imports: [RouterOutlet, ToastComponent],
+  template: '<router-outlet></router-outlet><app-toast />',
 })
 export class AppComponent implements OnInit {
   private readonly authService = inject(AuthService);

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs';
 
 import { routes } from './app.routes';
 import { authInterceptor } from '@core/interceptors/auth.interceptor';
-// import { errorInterceptor } from '@core/interceptors/error.interceptor';
+import { errorInterceptor } from '@core/interceptors/error.interceptor';
 
 export function httpLoaderFactory(http: HttpClient): TranslateLoader {
   return {
@@ -22,7 +22,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
     provideHttpClient(
-      withInterceptors([authInterceptor])
+      withInterceptors([authInterceptor, errorInterceptor])
     ),
     importProvidersFrom(
       TranslateModule.forRoot({

--- a/frontend/src/app/core/interceptors/error.interceptor.spec.ts
+++ b/frontend/src/app/core/interceptors/error.interceptor.spec.ts
@@ -1,21 +1,33 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptors, HttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
 import { errorInterceptor } from './error.interceptor';
-import { HttpClient } from '@angular/common/http';
+import { AuthService } from '@core/services/auth.service';
+import { ToastService } from '@core/services/toast.service';
 
-describe('ErrorInterceptor', () => {
+describe('errorInterceptor', () => {
   let httpMock: HttpTestingController;
   let httpClient: HttpClient;
+  let mockAuth: jest.Mocked<Pick<AuthService, 'isAuthenticated' | 'clearSession'>>;
+  let mockRouter: { navigateByUrl: jest.Mock };
+  let mockToast: { show: jest.Mock };
 
   beforeEach(() => {
+    mockAuth = {
+      isAuthenticated: jest.fn().mockReturnValue(false),
+      clearSession: jest.fn(),
+    };
+    mockRouter = { navigateByUrl: jest.fn() };
+    mockToast = { show: jest.fn() };
+
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
-        {
-          provide: 'HTTP_INTERCEPTORS',
-          useValue: errorInterceptor,
-          multi: true,
-        },
+        provideHttpClient(withInterceptors([errorInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: mockAuth },
+        { provide: Router, useValue: mockRouter },
+        { provide: ToastService, useValue: mockToast },
       ],
     });
 
@@ -23,69 +35,170 @@ describe('ErrorInterceptor', () => {
     httpClient = TestBed.inject(HttpClient);
   });
 
-  afterEach(() => {
-    httpMock.verify();
+  afterEach(() => httpMock.verify());
+
+  it('should pass through successful responses unchanged', (done) => {
+    httpClient.get('/api/test').subscribe({
+      next: (data) => { expect(data).toEqual({ ok: true }); done(); },
+    });
+    httpMock.expectOne('/api/test').flush({ ok: true });
   });
 
-  it('should be created', () => {
-    expect(errorInterceptor).toBeDefined();
-  });
+  describe('401 Unauthorized', () => {
+    it('clears session and redirects when user was authenticated', (done) => {
+      mockAuth.isAuthenticated.mockReturnValue(true);
 
-  it('should handle successful responses', (done) => {
-    const testData = { message: 'success' };
+      httpClient.get('/api/secure').subscribe({
+        error: () => {
+          expect(mockAuth.clearSession).toHaveBeenCalled();
+          expect(mockRouter.navigateByUrl).toHaveBeenCalledWith('/login');
+          expect(mockToast.show).toHaveBeenCalledWith(expect.stringContaining('Session expired'));
+          done();
+        },
+      });
 
-    httpClient.get('/api/test').subscribe((data) => {
-      expect(data).toEqual(testData);
-      done();
+      httpMock.expectOne('/api/secure').flush(
+        { error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } },
+        { status: 401, statusText: 'Unauthorized' }
+      );
     });
 
-    const req = httpMock.expectOne('/api/test');
-    expect(req.request.method).toBe('GET');
-    req.flush(testData);
+    it('does NOT clear session or redirect when user was not authenticated (e.g. login form)', (done) => {
+      mockAuth.isAuthenticated.mockReturnValue(false);
+
+      httpClient.post('/api/auth/login', {}).subscribe({
+        error: () => {
+          expect(mockAuth.clearSession).not.toHaveBeenCalled();
+          expect(mockRouter.navigateByUrl).not.toHaveBeenCalled();
+          expect(mockToast.show).not.toHaveBeenCalled();
+          done();
+        },
+      });
+
+      httpMock.expectOne('/api/auth/login').flush(
+        { error: { code: 'UNAUTHORIZED', message: 'Invalid credentials' } },
+        { status: 401, statusText: 'Unauthorized' }
+      );
+    });
   });
 
-  it('should pass through GET requests', (done) => {
-    httpClient.get('/api/data').subscribe(() => {
-      done();
-    });
+  describe('403 Forbidden', () => {
+    it('shows a warning toast without redirecting', (done) => {
+      httpClient.get('/api/admin').subscribe({
+        error: () => {
+          expect(mockToast.show).toHaveBeenCalledWith(
+            expect.stringContaining("permission"),
+            'warning'
+          );
+          expect(mockRouter.navigateByUrl).not.toHaveBeenCalled();
+          done();
+        },
+      });
 
-    const req = httpMock.expectOne('/api/data');
-    expect(req.request.method).toBe('GET');
-    req.flush({});
+      httpMock.expectOne('/api/admin').flush(
+        { error: { code: 'FORBIDDEN', message: 'Access denied' } },
+        { status: 403, statusText: 'Forbidden' }
+      );
+    });
   });
 
-  it('should pass through POST requests', (done) => {
-    const postData = { name: 'test' };
+  describe('Network error (status 0)', () => {
+    it('shows a network error toast', (done) => {
+      httpClient.get('/api/data').subscribe({
+        error: () => {
+          expect(mockToast.show).toHaveBeenCalledWith(
+            expect.stringContaining('Network error')
+          );
+          done();
+        },
+      });
 
-    httpClient.post('/api/data', postData).subscribe(() => {
-      done();
+      httpMock.expectOne('/api/data').error(new ProgressEvent('error'));
     });
-
-    const req = httpMock.expectOne('/api/data');
-    expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual(postData);
-    req.flush({});
   });
 
-  it('should pass through PUT requests', (done) => {
-    const updateData = { id: 1, name: 'updated' };
+  describe('5xx Server Errors', () => {
+    it('shows a server error toast for 500', (done) => {
+      httpClient.get('/api/data').subscribe({
+        error: () => {
+          expect(mockToast.show).toHaveBeenCalledWith(
+            expect.stringContaining('Something went wrong')
+          );
+          done();
+        },
+      });
 
-    httpClient.put('/api/data/1', updateData).subscribe(() => {
-      done();
+      httpMock.expectOne('/api/data').flush(
+        { error: { code: 'INTERNAL_SERVER_ERROR', message: 'Internal Server Error' } },
+        { status: 500, statusText: 'Internal Server Error' }
+      );
     });
 
-    const req = httpMock.expectOne('/api/data/1');
-    expect(req.request.method).toBe('PUT');
-    req.flush({});
+    it('shows a server error toast for 503', (done) => {
+      httpClient.get('/api/data').subscribe({
+        error: () => {
+          expect(mockToast.show).toHaveBeenCalledWith(
+            expect.stringContaining('Something went wrong')
+          );
+          done();
+        },
+      });
+
+      httpMock.expectOne('/api/data').flush(
+        {},
+        { status: 503, statusText: 'Service Unavailable' }
+      );
+    });
   });
 
-  it('should pass through DELETE requests', (done) => {
-    httpClient.delete('/api/data/1').subscribe(() => {
-      done();
+  describe('413 Payload Too Large', () => {
+    it('shows a warning toast with the file size message', (done) => {
+      httpClient.post('/api/upload', {}).subscribe({
+        error: () => {
+          expect(mockToast.show).toHaveBeenCalledWith(
+            expect.stringContaining('25MB'),
+            'warning'
+          );
+          done();
+        },
+      });
+
+      httpMock.expectOne('/api/upload').flush(
+        { error: { code: 'PAYLOAD_TOO_LARGE', message: 'Request body is too large. Current limit is 25MB.' } },
+        { status: 413, statusText: 'Content Too Large' }
+      );
+    });
+  });
+
+  describe('Other errors (4xx, etc.)', () => {
+    it('re-throws the error without showing a toast for 404', (done) => {
+      httpClient.get('/api/missing').subscribe({
+        error: (err) => {
+          expect(err.status).toBe(404);
+          expect(mockToast.show).not.toHaveBeenCalled();
+          done();
+        },
+      });
+
+      httpMock.expectOne('/api/missing').flush(
+        { error: { code: 'NOT_FOUND', message: 'Not found' } },
+        { status: 404, statusText: 'Not Found' }
+      );
     });
 
-    const req = httpMock.expectOne('/api/data/1');
-    expect(req.request.method).toBe('DELETE');
-    req.flush({});
+    it('re-throws the error without showing a toast for 422', (done) => {
+      httpClient.post('/api/data', {}).subscribe({
+        error: (err) => {
+          expect(err.status).toBe(422);
+          expect(mockToast.show).not.toHaveBeenCalled();
+          done();
+        },
+      });
+
+      httpMock.expectOne('/api/data').flush(
+        {},
+        { status: 422, statusText: 'Unprocessable Entity' }
+      );
+    });
   });
 });

--- a/frontend/src/app/core/interceptors/error.interceptor.ts
+++ b/frontend/src/app/core/interceptors/error.interceptor.ts
@@ -1,7 +1,48 @@
-import { HttpInterceptorFn } from '@angular/common/http';
+import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, throwError } from 'rxjs';
+import { AuthService } from '@core/services/auth.service';
+import { ToastService } from '@core/services/toast.service';
 
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  const toast = inject(ToastService);
+
   return next(req).pipe(
-    // TODO: Add error handling logic
+    catchError((error: HttpErrorResponse) => {
+      switch (true) {
+        case error.status === 401:
+          // Only treat as session expiry if the user had a valid session.
+          // Login-form 401s (wrong credentials, no existing token) pass through
+          // to the component's own error handler.
+          if (auth.isAuthenticated()) {
+            auth.clearSession();
+            router.navigateByUrl('/login');
+            toast.show('Session expired. Please log in again.');
+          }
+          break;
+
+        case error.status === 403:
+          toast.show("You don't have permission to do that.", 'warning');
+          break;
+
+        case error.status === 413:
+          toast.show('File is too large. Maximum allowed size is 25MB.', 'warning');
+          break;
+
+        case error.status === 0:
+          // Network error — no HTTP response received
+          toast.show('Network error. Please check your connection.');
+          break;
+
+        case error.status >= 500:
+          toast.show('Something went wrong on the server. Please try again.');
+          break;
+      }
+
+      return throwError(() => error);
+    })
   );
 };

--- a/frontend/src/app/core/services/toast.service.ts
+++ b/frontend/src/app/core/services/toast.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export type ToastType = 'error' | 'warning' | 'success' | 'info';
+
+export interface Toast {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private readonly _toasts$ = new BehaviorSubject<Toast[]>([]);
+  readonly toasts$ = this._toasts$.asObservable();
+  private nextId = 0;
+
+  show(message: string, type: ToastType = 'error', duration = 4000): void {
+    const toast: Toast = { id: this.nextId++, message, type };
+    this._toasts$.next([...this._toasts$.value, toast]);
+    window.setTimeout(() => this.dismiss(toast.id), duration);
+  }
+
+  dismiss(id: number): void {
+    this._toasts$.next(this._toasts$.value.filter(t => t.id !== id));
+  }
+}

--- a/frontend/src/app/shared/components/index.ts
+++ b/frontend/src/app/shared/components/index.ts
@@ -3,3 +3,4 @@ export * from './language-switcher/language-switcher.component';
 export * from './page-stub/page-stub.component';
 export * from './public-footer/public-footer.component';
 export * from './public-layout/public-layout.component';
+export * from './toast/toast.component';

--- a/frontend/src/app/shared/components/toast/toast.component.ts
+++ b/frontend/src/app/shared/components/toast/toast.component.ts
@@ -1,0 +1,40 @@
+import { Component, inject } from '@angular/core';
+import { AsyncPipe, NgClass } from '@angular/common';
+import { ToastService } from '@core/services/toast.service';
+
+@Component({
+  selector: 'app-toast',
+  standalone: true,
+  imports: [AsyncPipe, NgClass],
+  template: `
+    <div class="fixed top-4 right-4 z-[9999] flex flex-col gap-2 pointer-events-none">
+      @for (toast of toasts$ | async; track toast.id) {
+        <div
+          class="flex items-center gap-3 rounded-lg px-4 py-3 text-white shadow-lg text-sm max-w-sm pointer-events-auto animate-fade-in"
+          [ngClass]="{
+            'bg-red-600':    toast.type === 'error',
+            'bg-yellow-500': toast.type === 'warning',
+            'bg-green-600':  toast.type === 'success',
+            'bg-blue-600':   toast.type === 'info'
+          }"
+        >
+          <span class="flex-1">{{ toast.message }}</span>
+          <button
+            type="button"
+            (click)="dismiss(toast.id)"
+            class="ml-2 opacity-70 hover:opacity-100 transition-opacity"
+            aria-label="Dismiss"
+          >✕</button>
+        </div>
+      }
+    </div>
+  `,
+})
+export class ToastComponent {
+  private readonly toastService = inject(ToastService);
+  readonly toasts$ = this.toastService.toasts$;
+
+  dismiss(id: number): void {
+    this.toastService.dismiss(id);
+  }
+}


### PR DESCRIPTION

## Summary

The `errorInterceptor` in `core/interceptors/error.interceptor.ts` was a no-op stub with a TODO comment. This PR implements the full global HTTP error handler: it catches 401 (session expiry), 403 (forbidden), 413 (payload too large), network failures (status 0), and 5xx server errors, showing user-facing toast notifications for each. A new `ToastService` and `ToastComponent` are introduced since no toast/notification system existed in the app.

## Related References

- Issue: #110
- Related UC: UC2–UC4 (any authenticated action that can fail with 401/403)

## What Changed

- [x] Frontend
- [ ] Backend
- [ ] Database / Supabase
- [ ] CI/CD
- [ ] Documentation
- [x] Tests

## Implementation Notes

- **401 guard**: the interceptor only clears the session and redirects to `/login` when `auth.isAuthenticated()` is true — this prevents login-form wrong-credential 401s from triggering a redirect loop.
- **Toast messages are all hardcoded** — no server error detail is ever shown to the user, which avoids leaking internal error messages.
- `ToastService` uses a `BehaviorSubject<Toast[]>` so any component can subscribe; auto-dismiss is scheduled via `window.setTimeout` (Zone.js patches this so Angular's default CD picks it up correctly).
- `ToastComponent` is mounted once at the app root in `AppComponent`, rendering a fixed top-right overlay with color-coded badges (red=error, yellow=warning, green=success, blue=info).
- The 413 case matches the backend's `MaxUploadSizeExceededException` handler which returns `{ code: "PAYLOAD_TOO_LARGE" }` on file uploads > 25MB.

## Source Of Truth Check

- [ ] `docs/architecture/api-endpoints.md`
- [ ] `docs/architecture/database.md`
- [ ] Relevant `docs/tasks/...`
- [ ] Relevant `docs/SUC/...`
- [x] Related README files if setup changed — no setup change required

## Verification

```text
cd frontend
npm run lint        # 0 errors
npm run build       # clean build
npm run test:ci     # 514 tests, 46 suites — all pass
```

Error interceptor spec covers:

- Passthrough on 2xx
- 401 when authenticated → clears session, redirects, shows toast
- 401 when NOT authenticated → no redirect, no toast (login form handles it)
- 403 → warning toast
- 413 → warning toast with size limit message
- Network error (status 0) → error toast
- 500/503 → error toast
- 404/422 → rethrown silently (components handle their own not-found/validation errors)

## Checklist

- [x] I tested the changed behavior locally
- [x] I updated docs if behavior, routes, schema, or setup changed — no docs change needed
- [x] I did not leave stale route, model, or enum names behind
- [x] I kept issue/task/docs naming consistent with the current source of truth
- [x] I added or updated tests where the change has meaningful risk

## Breaking Changes

None.

## Follow-Up Work

- Toast messages are English-only; i18n keys could replace hardcoded strings in a future pass.

Closes #110
